### PR TITLE
Updated SF setup

### DIFF
--- a/apps/ttalps_histogrammer.cpp
+++ b/apps/ttalps_histogrammer.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
 
     map<string,float> eventWeights = asTTAlpsEvent(event)->GetEventWeights();
     histogramsHandler->SetEventWeights(eventWeights);
-    cutFlowManager->SetEventWeights(eventWeights);
+    cutFlowManager->SetEventWeight(eventWeights["systematic"]);
 
     bool passesDimuonCuts = false;
     for (string category : categories) {

--- a/apps/ttalps_histogrammer.cpp
+++ b/apps/ttalps_histogrammer.cpp
@@ -55,9 +55,6 @@ int main(int argc, char **argv) {
   config.GetValue("runGenMuonVertexCollectionHistograms", runGenMuonVertexCollectionHistograms);
   config.GetValue("runABCDHistograms", runABCDHistograms);
 
-  if (runPileupHistograms) cutFlowManager->RegisterCut("initial");
-
-  // check if cutflowmanager has cut "initial"
   cutFlowManager->RegisterCut("initial");
 
   auto categories = {"", "Pat", "PatDSA", "DSA"};
@@ -76,6 +73,10 @@ int main(int argc, char **argv) {
     ttalpsObjectsManager->InsertNminus1VertexCollections(event);
     ttalpsObjectsManager->InsertBaseLooseMuonVertexCollection(event);
 
+    map<string,float> eventWeights = asTTAlpsEvent(event)->GetEventWeights();
+    histogramsHandler->SetEventWeights(eventWeights);
+    cutFlowManager->SetEventWeights(eventWeights);
+
     bool passesDimuonCuts = false;
     for (string category : categories) {
       passesDimuonCuts |= ttAlpsCuts->PassesDimuonCuts(event, cutFlowManager, category);
@@ -85,6 +86,7 @@ int main(int argc, char **argv) {
     if (runDefaultHistograms) {
       cutFlowManager->UpdateCutFlow("initial");
       ttalpsHistogramsFiller->FillNormCheck(event);
+      ttalpsHistogramsFiller->FillDataCheck(event);
       ttalpsHistogramsFiller->FillDefaultVariables(event);
     }
     if (runLLPNanoAODHistograms) {
@@ -103,7 +105,7 @@ int main(int argc, char **argv) {
       ttalpsHistogramsFiller->FillCustomTTAlpsGenMuonVertexCollectionsVariables(event);
     }
 
-    if (runLLPTriggerHistograms && passesDimuonCuts) {
+    if (runLLPTriggerHistograms) {
       ttalpsHistogramsFiller->FillTriggerStudyHistograms(event, "NoExtraTrigger");
       
       if (ttAlpsCuts->PassesSingleMuonTrigger(event)) {
@@ -132,7 +134,6 @@ int main(int argc, char **argv) {
       ttalpsHistogramsFiller->FillDimuonCutFlows(cutFlowManager, category);
     }
   }
-
   cutFlowManager->Print();
   histogramsHandler->SaveHistograms();
 

--- a/apps/ttalps_histogrammer.cpp
+++ b/apps/ttalps_histogrammer.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
     
     if (runDefaultHistograms) {
       cutFlowManager->UpdateCutFlow("initial");
-      ttalpsHistogramsFiller->FillNormCheck(event);
+      ttalpsHistogramsFiller->FillNormCheck();
       ttalpsHistogramsFiller->FillDataCheck(event);
       ttalpsHistogramsFiller->FillDefaultVariables(event);
     }
@@ -112,6 +112,9 @@ int main(int argc, char **argv) {
       }
       if (ttAlpsCuts->PassesDoubleMuonTrigger(event)) {
         ttalpsHistogramsFiller->FillTriggerStudyHistograms(event, "DoubleMuonTrigger");
+      }
+      if (ttAlpsCuts->PassesSingleMuonTrigger(event) || ttAlpsCuts->PassesDoubleMuonTrigger(event)) {
+        ttalpsHistogramsFiller->FillTriggerStudyHistograms(event, "SingleorDoubleMuonTrigger");
       }
     }
     if (runABCDHistograms) {

--- a/apps/ttalps_histogrammer.cpp
+++ b/apps/ttalps_histogrammer.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
 
     map<string,float> eventWeights = asTTAlpsEvent(event)->GetEventWeights();
     histogramsHandler->SetEventWeights(eventWeights);
-    cutFlowManager->SetEventWeight(eventWeights["systematic"]);
+    cutFlowManager->SetEventWeight(eventWeights["default"]);
 
     bool passesDimuonCuts = false;
     for (string category : categories) {

--- a/apps/ttalps_histogrammer.cpp
+++ b/apps/ttalps_histogrammer.cpp
@@ -43,12 +43,11 @@ int main(int argc, char **argv) {
   auto ttAlpsCuts = make_unique<TTAlpsCuts>();
   auto ttalpsObjectsManager = make_unique<TTAlpsObjectsManager>();
 
-  bool runDefaultHistograms, runLLPTriggerHistograms, runPileupHistograms;
+  bool runDefaultHistograms, runLLPTriggerHistograms;
   bool runLLPNanoAODHistograms, runMuonMatchingHistograms, runGenMuonHistograms, runGenMuonVertexCollectionHistograms;
   bool runABCDHistograms;
   config.GetValue("runDefaultHistograms", runDefaultHistograms);
   config.GetValue("runLLPTriggerHistograms", runLLPTriggerHistograms);
-  config.GetValue("runPileupHistograms", runPileupHistograms);
   config.GetValue("runLLPNanoAODHistograms", runLLPNanoAODHistograms);
   config.GetValue("runMuonMatchingHistograms", runMuonMatchingHistograms);
   config.GetValue("runGenMuonHistograms", runGenMuonHistograms);
@@ -82,7 +81,7 @@ int main(int argc, char **argv) {
       passesDimuonCuts |= ttAlpsCuts->PassesDimuonCuts(event, cutFlowManager, category);
     }
     if (!passesDimuonCuts) continue;
-
+    
     if (runDefaultHistograms) {
       cutFlowManager->UpdateCutFlow("initial");
       ttalpsHistogramsFiller->FillNormCheck(event);
@@ -115,18 +114,12 @@ int main(int argc, char **argv) {
         ttalpsHistogramsFiller->FillTriggerStudyHistograms(event, "DoubleMuonTrigger");
       }
     }
-
-    if (runPileupHistograms) {
-      cutFlowManager->UpdateCutFlow("initial");
-      histogramFiller->FillDefaultVariables(event);
-    }
-
     if (runABCDHistograms) {
       ttalpsHistogramsFiller->FillABCDHistograms(event);
     }
   }
 
-  if (runDefaultHistograms || runPileupHistograms) {
+  if (runDefaultHistograms) {
     histogramFiller->FillCutFlow(cutFlowManager);
   }
   if (runDefaultHistograms) {

--- a/apps/ttalps_skimmer.cpp
+++ b/apps/ttalps_skimmer.cpp
@@ -63,8 +63,8 @@ int main(int argc, char **argv) {
     auto event = eventReader->GetEvent(iEvent);
     ttalpsObjectsManager->InsertMatchedLooseMuonsCollections(event);
 
-    map<string,float> eventWeights = asTTAlpsEvent(event)->GetEventWeights();
-    cutFlowManager->SetEventWeight(eventWeights["systematic"]);
+    // map<string,float> eventWeights = asTTAlpsEvent(event)->GetEventWeights();
+    // cutFlowManager->SetEventWeight(eventWeights["default"]);
 
     cutFlowManager->UpdateCutFlow("initial");
 

--- a/apps/ttalps_skimmer.cpp
+++ b/apps/ttalps_skimmer.cpp
@@ -63,6 +63,9 @@ int main(int argc, char **argv) {
     auto event = eventReader->GetEvent(iEvent);
     ttalpsObjectsManager->InsertMatchedLooseMuonsCollections(event);
 
+    map<string,float> eventWeights = asTTAlpsEvent(event)->GetEventWeights();
+    cutFlowManager->SetEventWeight(eventWeights["systematic"]);
+
     cutFlowManager->UpdateCutFlow("initial");
 
     

--- a/configs/ttalps_histogrammer_config.py
+++ b/configs/ttalps_histogrammer_config.py
@@ -103,19 +103,26 @@ histParams2D = ()
 
 helper = TTAlpsHistogrammerConfigHelper(muonMatchingParams, muonVertexCollection[0] if muonVertexCollection is not None else None)
 
-
 defaultHistParams = helper.get_default_params()
-
 histParams += helper.get_basic_params()
-histParams += helper.get_llp_params()
-histParams += helper.get_nminus1_params()
-histParams += helper.get_gen_matched_params()
-histParams += helper.get_gen_params()
-histParams += helper.get_trigger_params()
-histParams += helper.get_matching_params()
 
-histParams2D += helper.get_2D_params()
-histParams2D += helper.get_abcd_params()
-histParams2D += helper.get_2D_matching_params()
+if runLLPNanoAODHistograms:
+    histParams += helper.get_llp_params()
 
-extraSFsHistParams2D = helper.get_abcd_params()
+if runGenMuonVertexCollectionHistograms:
+    histParams += helper.get_gen_vertex_params()
+if runGenMuonHistograms:
+    histParams += helper.get_gen_params()
+    histParams += helper.get_gen_matched_params()
+
+if runLLPTriggerHistograms:
+    histParams += helper.get_trigger_params()
+if runMuonMatchingHistograms:
+    histParams += helper.get_matching_params()
+    histParams2D += helper.get_2D_matching_params()
+
+if runABCDHistograms:
+    histParams += helper.get_abcd_1Dparams()
+    histParams2D += helper.get_abcd_2Dparams()
+
+extraSFsHistParams2D = helper.get_abcd_2Dparams()

--- a/configs/ttalps_histogrammer_config.py
+++ b/configs/ttalps_histogrammer_config.py
@@ -53,7 +53,11 @@ extraSFs = [
     "btagUpUncorrelated", 
     "btagDownUncorrelated", 
     "pujetIDUp", 
-    "pujetIDDown"
+    "pujetIDDown",
+    "muonUp",
+    "muonDown",
+    "muonTriggerUp",
+    "muonTriggerDown"
 ]
 
 # For the signal histogramming all given mathcing methods are applied separately to histograms

--- a/configs/ttalps_histogrammer_config.py
+++ b/configs/ttalps_histogrammer_config.py
@@ -19,7 +19,7 @@ runPileupHistograms = False
 #  - muonMatchingParams loose muons
 #  - muonMatchingParams loose muon vertex
 #  - extra muon vertex collections
-runLLPNanoAODHistograms = False
+runLLPNanoAODHistograms = True
 
 runMuonMatchingHistograms = False  # TODO: this doesn't seem to work
 runGenMuonHistograms = False  # can only be run on signal samples
@@ -92,7 +92,7 @@ if dimuonSelection is not None:
 histParams = ()
 histParams2D = ()
 
-helper = TTAlpsHistogrammerConfigHelper(muonMatchingParams, muonVertexCollection[0] if muonVertexCollection is not None else None)
+helper = TTAlpsHistogrammerConfigHelper(muonMatchingParams, muonVertexCollection if muonVertexCollection is not None else None)
 
 defaultHistParams = helper.get_default_params()
 histParams += helper.get_basic_params()

--- a/configs/ttalps_histogrammer_config.py
+++ b/configs/ttalps_histogrammer_config.py
@@ -19,7 +19,7 @@ runPileupHistograms = False
 #  - muonMatchingParams loose muons
 #  - muonMatchingParams loose muon vertex
 #  - extra muon vertex collections
-runLLPNanoAODHistograms = True
+runLLPNanoAODHistograms = False
 
 runMuonMatchingHistograms = False  # TODO: this doesn't seem to work
 runGenMuonHistograms = False  # can only be run on signal samples
@@ -46,19 +46,6 @@ applyScaleFactors = {
     "bTagging": True,
     "PUjetID": True,
 }
-# Extra up/down SFs: comment out all to run not include them in histograms
-extraSFs = [ 
-    "btagUpCorrelated", 
-    "btagDownCorrelated", 
-    "btagUpUncorrelated", 
-    "btagDownUncorrelated", 
-    "pujetIDUp", 
-    "pujetIDDown",
-    "muonUp",
-    "muonDown",
-    "muonTriggerUp",
-    "muonTriggerDown"
-]
 
 # For the signal histogramming all given mathcing methods are applied separately to histograms
 # More than one given method will not affect the other histograms
@@ -129,4 +116,4 @@ if runABCDHistograms:
     histParams += helper.get_abcd_1Dparams()
     histParams2D += helper.get_abcd_2Dparams()
 
-extraSFsHistParams2D = helper.get_abcd_2Dparams()
+SFvariationVariables = helper.get_SF_variation_variables()

--- a/configs/ttalps_histogrammer_config.py
+++ b/configs/ttalps_histogrammer_config.py
@@ -44,8 +44,17 @@ applyScaleFactors = {
     "muonTrigger": True,
     "pileup": True,
     "bTagging": True,
-    "PUjetID": False,
+    "PUjetID": True,
 }
+# Extra up/down SFs: comment out all to run not include them in histograms
+extraSFs = [ 
+    "btagUpCorrelated", 
+    "btagDownCorrelated", 
+    "btagUpUncorrelated", 
+    "btagDownUncorrelated", 
+    "pujetIDUp", 
+    "pujetIDDown"
+]
 
 # For the signal histogramming all given mathcing methods are applied separately to histograms
 # More than one given method will not affect the other histograms
@@ -108,3 +117,5 @@ histParams += helper.get_matching_params()
 histParams2D += helper.get_2D_params()
 histParams2D += helper.get_abcd_params()
 histParams2D += helper.get_2D_matching_params()
+
+extraSFsHistParams2D = helper.get_abcd_params()

--- a/configs/ttalps_histogrammer_files_config.py
+++ b/configs/ttalps_histogrammer_files_config.py
@@ -1,7 +1,7 @@
 from ttalps_samples_list import *
 import os
 
-max_files = -1
+max_files = 1-
 
 # input_username = "lrygaard"
 input_username = "jniedzie"
@@ -10,18 +10,18 @@ input_username = "jniedzie"
 # skim = ("skimmed_looseSemimuonic_v2", "")
 
 # SR (+J/Psi CR), tt̄ CR, and QCD CR, with no isolation requirement on the loose muons
-# skim = ("skimmed_looseSemimuonic_v2_SR", "_SRDimuons")
+skim = ("skimmed_looseSemimuonic_v2_SR", "_SRDimuons")
 # skim = ("skimmed_looseSemimuonic_v2_SR", "_JPsiDimuons")
 # skim = ("skimmed_looseSemimuonic_v2_SR", "_ZDimuons")
 # skim = ("skimmed_looseSemimuonic_v2_ttbarCR", "")
 # skim = ("skimmed_looseNonTT_v1_QCDCR", "_SRDimuons")  # this is in fact VV CR
 # skim = ("skimmed_looseNoBjets_lt4jets_v1_QCDCR", "_SRDimuons")
 # skim = ("skimmed_loose_lt3bjets_lt4jets_v1_WjetsCR", "_SRDimuons")
-skim = ("skimmed_loose_lt3bjets_lt4jets_v1_bbCR", "_SRDimuons")
+# skim = ("skimmed_loose_lt3bjets_lt4jets_v1_bbCR", "_SRDimuons")
 
 # Loose semimuonic skim with Dimuon triggers for LLP trigger study
-# skim = ("skimmed_looseSemimuonicv1_LLPtrigger", "_SRDimuons_TriggerStudy")
-# skim = ("skimmed_looseSemimuonic_SRmuonic_Segmentv1_NonIso_LLPtrigger", "_SRDimuons_TriggerStudy")
+# skim = ("skimmed_looseSemimuonic_v2_LLPtrigger_SR", "_SRDimuons")
+# skim = ("skimmed_looseSemimuonic_v2_notrigger_SR", "_SRDimuons")
 
 samples = dasSamples2018.keys()
 # samples = dasData2018.keys()
@@ -38,7 +38,7 @@ applyScaleFactors = {
   "muonTrigger": True,
   "pileup": True,
   "bTagging": True,
-  "PUjetID": False,  # no need to apply jet ID SFs in UL
+  "PUjetID": True,
 }
 
 # this has to be here, otherwise the script will not work:

--- a/configs/ttalps_histogrammer_files_config.py
+++ b/configs/ttalps_histogrammer_files_config.py
@@ -1,7 +1,7 @@
 from ttalps_samples_list import *
 import os
 
-max_files = 1-
+max_files = -1
 
 # input_username = "lrygaard"
 input_username = "jniedzie"

--- a/configs/ttalps_met_filters.py
+++ b/configs/ttalps_met_filters.py
@@ -1,0 +1,40 @@
+
+met_filters_run2_base = {
+  "Flag_goodVertices",
+  "Flag_globalSuperTightHalo2016Filter",
+  "Flag_HBHENoiseFilter",
+  "Flag_HBHENoiseIsoFilter",
+  "Flag_BadPFMuonFilter",
+  "Flag_BadPFMuonDzFilter",
+  "Flag_hfNoisyHitsFilter",
+  "Flag_eeBadScFilter",
+}
+
+met_filters_2017_2018 = {
+  "Flag_EcalDeadCellTriggerPrimitiveFilter",
+  "Flag_ecalBadCalibFilter",
+}
+
+met_filters_2016 = {
+  "EcalDeadCellTriggerPrimitiveFilter",
+}
+
+# Filters given for preompt-reco Run 3 data and MC, not rereco yet:
+met_filters_run3_base = {
+  "Flag_goodVertices",
+  "Flag_globalSuperTightHalo2016Filter",
+  "Flag_BadPFMuonFilter",
+  "Flag_BadPFMuonDzFilter",
+  "Flag_hfNoisyHitsFilter",
+  "Flag_eeBadScFilter",
+  "Flag_EcalDeadCellTriggerPrimitiveFilter",
+  "Flag_ecalBadCalibFilter",
+}
+
+def get_met_filters(year):
+  if year == "2016preVFP" or year == "2016postVFP":
+    return met_filters_run2_base.union(met_filters_2016)
+  elif year == "2018" or year == "2017":
+    return met_filters_run2_base.union(met_filters_2017_2018)
+  elif year == "2022preEE" or year == "2022postEE" or year == "2023preBPix" or year == "2023postBPix":
+    return met_filters_run3_base

--- a/configs/ttalps_object_cuts.py
+++ b/configs/ttalps_object_cuts.py
@@ -30,8 +30,8 @@ JPsiDimuonVertexCuts = {
     # For different dimuon categories in order: PAT-PAT,PAT-DSA,DSA-DSA
     "maxChargeProduct": [-0.1, -0.1, -0.1],
     # J/Psi mass cut
-    "maxInvariantMass": [3.3, 3.3, 3.3],
-    "minInvariantMass": [2.9, 2.9, 2.9],
+    "maxInvariantMass": [3.2, 3.2, 3.2],
+    "minInvariantMass": [3.0, 3.0, 3.0],
     "maxDCA": [9999.0, 2.0, 2.0],
     "maxChi2": [3.0, 3.0, 3.0],
     "maxHitsInFrontOfVertex": [3.0, 6.0, 9999.0],

--- a/configs/ttalps_plotter_config.py
+++ b/configs/ttalps_plotter_config.py
@@ -27,13 +27,7 @@ skim = ("skimmed_looseSemimuonic_v2_SR", "_JPsiDimuons")
 # skim = ("skimmed_loose_lt3bjets_lt4jets_v1_bbCR", "_SRDimuons")
 
 # hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs{skim[1]}"
-# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}"
-hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # all SFs
-# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs{skim[1]}_newSFs" # no PUjetIDSFs
-# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_PUjetIDSFs{skim[1]}_newSFs" # no bTaggingSFs
-# hist_path = f"histograms_muonSFs_muonTriggerSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no pileup
-# hist_path = f"histograms_muonSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no muonTriggerSF
-# hist_path = f"histograms_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no muonSF
+hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}"
 
 output_formats = ["pdf"]
 

--- a/configs/ttalps_plotter_config.py
+++ b/configs/ttalps_plotter_config.py
@@ -19,14 +19,21 @@ base_path = f"/data/dust/user/{os.environ['USER']}/ttalps_cms/"
 
 # skim = ("skimmed_looseSemimuonic_v2_ttbarCR", "")
 # skim = ("skimmed_looseSemimuonic_v2_SR", "_SRDimuons")
-# skim = ("skimmed_looseSemimuonic_v2_SR", "_JPsiDimuons")
+skim = ("skimmed_looseSemimuonic_v2_SR", "_JPsiDimuons")
 # skim = ("skimmed_looseSemimuonic_v2_SR", "_ZDimuons")
 # skim = ("skimmed_looseNonTT_v1_QCDCR", "_SRDimuons")  # this is in fact VV CR
 # skim = ("skimmed_looseNoBjets_lt4jets_v1_QCDCR", "_SRDimuons")
 # skim = ("skimmed_loose_lt3bjets_lt4jets_v1_WjetsCR", "_SRDimuons")
-skim = ("skimmed_loose_lt3bjets_lt4jets_v1_bbCR", "_SRDimuons")
+# skim = ("skimmed_loose_lt3bjets_lt4jets_v1_bbCR", "_SRDimuons")
 
-hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs{skim[1]}"
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs{skim[1]}"
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}"
+hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # all SFs
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs{skim[1]}_newSFs" # no PUjetIDSFs
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_PUjetIDSFs{skim[1]}_newSFs" # no bTaggingSFs
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no pileup
+# hist_path = f"histograms_muonSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no muonTriggerSF
+# hist_path = f"histograms_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no muonSF
 
 output_formats = ["pdf"]
 
@@ -54,8 +61,8 @@ extraText = "Preliminary"
 
 extraMuonVertexCollections = [
   # "MaskedDimuonVerex",      # invariant mass cut only
-  # "BestDimuonVertex",       # best Dimuon selection without isolation cut
-  "BestPFIsoDimuonVertex",  # best Dimuon selection with isolation cut
+  "BestDimuonVertex",       # best Dimuon selection without isolation cut
+  # "BestPFIsoDimuonVertex",  # best Dimuon selection with isolation cut
 ]
 
 # Gen-level resonances plots - comment out to avoid plots for these collections 
@@ -73,15 +80,15 @@ data_to_include = [
 ]
 
 backgrounds_to_exclude = [
-  "QCD_Pt-15To20_MuEnrichedPt5_TuneCP5_13TeV-pythia8",
-  "QCD_Pt-20To30_MuEnrichedPt5_TuneCP5_13TeV-pythia8",
-  "QCD_Pt-30To50_MuEnrichedPt5_TuneCP5_13TeV-pythia8",
+  # "QCD_Pt-15To20_MuEnrichedPt5_TuneCP5_13TeV-pythia8",
+  # "QCD_Pt-20To30_MuEnrichedPt5_TuneCP5_13TeV-pythia8",
+  # "QCD_Pt-30To50_MuEnrichedPt5_TuneCP5_13TeV-pythia8",
 ]
 
 signals_to_include = [
-  "tta_mAlp-0p35GeV_ctau-1e2mm", 
-  "tta_mAlp-0p35GeV_ctau-1e3mm", 
-  "tta_mAlp-0p35GeV_ctau-1e5mm"
+  # "tta_mAlp-2GeV_ctau-1e0mm", 
+  # "tta_mAlp-2GeV_ctau-1e1mm", 
+  # "tta_mAlp-2GeV_ctau-1e2mm"
 ]
 
 configHelper = TTAlpsPlotterConfigHelper(
@@ -135,6 +142,7 @@ histograms = (
   Histogram("dimuonCutFlow_BestDimuonVertex_DSA"   , "", False,  True  , default_norm              , 1  , 0     , 10    , 1e-1  , 1e4   , "Selection"                                      , "Number of events"  ),
   Histogram("dimuonCutFlow_BestDimuonVertex"       , "", False,  True  , default_norm              , 1  , 0     , 8     , 1e-1  , 1e2   , "Selection"                                      , "Number of events"  ),
   Histogram("Event_normCheck"                      , "", False,  True  , default_norm              , 1  , 0     , 1     , 1e-2  , 1e7   , "norm check"                                     , "# events (2018)"   ),
+  Histogram("Event_isData"                         , "", False,  True  , default_norm              , 1  , 0     , 2     , 1e-8  , 1e7   , "Is Data Event"                                  , "# events (2018)"   ),
   Histogram("Event_MET_pt"                         , "", False,  True  , default_norm              , 10 , 0     , 800   , 1e-8  , 1e9   , "MET p_{T} [GeV]"                                , "# events (2018)"   ),
   # Histogram("Event_nTightMuons"                   , "", False,  True  , default_norm              , 1  , 0     , 10    , 1e1   , 1e9   , "Number of tight #mu"                            , "# events (2018)"   ),
   # Histogram("Event_nLoosePATMuons"                , "", False,  True  , default_norm              , 1  , 0     , 10    , 1e1   , 1e9   , "Number of loose #mu"                            , "# events (2018)"   ),
@@ -148,7 +156,7 @@ histograms = (
   Histogram("TightMuons_pt"                       , "", False,  True  , default_norm              , 50 , 0     , 1000  , 1e-6  , 1e8   , "tight #mu p_{T} [GeV]"                          , "# events (2018)"   ),
   Histogram("TightMuons_leadingPt"                , "", False,  True  , default_norm              , 50 , 0     , 1000  , 1e-5  , 1e5   , "leading tight #mu p_{T} [GeV]"                  , "# events (2018)"   ),
   Histogram("TightMuons_subleadingPt"             , "", False,  True  , default_norm              , 50 , 0     , 1000  , 1e-5  , 1e4   , "all subleading tight #mu p_{T} [GeV]"           , "# events (2018)"   ),
-  Histogram("TightMuons_eta"                      , "", False,  True  , default_norm              , 10 , -3.0  , 5.0   , 1e0   , 1e5   , "tight #mu #eta"                                 , "# events (2018)"   ),
+  Histogram("TightMuons_eta"                      , "", False,  True  , default_norm              , 10 , -3.0  , 5.0   , 1e-3  , 1e6   , "tight #mu #eta"                                 , "# events (2018)"   ),
   Histogram("TightMuons_dxy"                      , "", False,  True  , default_norm              , 2  , -0.5  , 0.5   , 1e-2  , 1e10  , "tight #mu d_{xy} [cm]"                          , "# events (2018)"   ),
   Histogram("TightMuons_dz"                       , "", False,  True  , default_norm              , 2  , -1    , 1     , 1e-2  , 1e8   , "tight #mu d_{z} [cm]"                           , "# events (2018)"   ),
   Histogram("TightMuons_pfRelIso04_all"           , "", False,  True  , default_norm              , 1  , 0.0   , 0.2   , 1e-2  , 1e6   , "tight #mu PF Rel Iso 0.4 (all)"                 , "# events (2018)"   ),
@@ -200,8 +208,8 @@ histograms = (
   # ----------------------------------------------------------------------------
   # Good jets
   # ----------------------------------------------------------------------------
-  # Histogram("GoodJets_pt"                         , "", False,  True  , default_norm              , 10 , 0     , 1300  , 1e-3  , 1e6   , "good jet p_{T} [GeV]"                           , "# events (2018)"   ),
-  # Histogram("GoodJets_eta"                        , "", False,  True  , default_norm              , 10 , -3    , 5.0   , 1e1   , 1e8   , "good jet #eta"                                  , "# events (2018)"   ),
+  Histogram("GoodJets_pt"                         , "", False,  True  , default_norm              , 10 , 0     , 1300  , 1e-3  , 1e6   , "good jet p_{T} [GeV]"                           , "# events (2018)"   ),
+  Histogram("GoodJets_eta"                        , "", False,  True  , default_norm              , 10 , -3    , 5.0   , 1e-3  , 1e6   , "good jet #eta"                                  , "# events (2018)"   ),
   # Histogram("GoodJets_btagDeepB"                  , "", False,  True  , default_norm              , 10 , 0     , 1.5   , 2e0   , 1e8   , "good jet deepCSV score"                         , "# events (2018)"   ),
   # Histogram("GoodJets_btagDeepFlavB"              , "", False,  True  , default_norm              , 10 , 0     , 1.8   , 1e-1  , 1e8   , "good jet deepJet score"                         , "# events (2018)"   ),
   # Histogram("GoodJets_minvBjet2jets"              , "", False,  True  , default_norm              , 25 , 0     , 1500  , 1e-1  , 1e5   , "good jets m_{bjj} [GeV]"                        , "# events (2018)"   ),
@@ -209,8 +217,8 @@ histograms = (
   # ----------------------------------------------------------------------------
   # Good b-jets
   # ----------------------------------------------------------------------------
-  # Histogram("GoodMediumBtaggedJets_pt"            , "", False,  True  , default_norm              , 50 , 0     , 2000  , 1e-5  , 1e4   , "good b-jet p_{T} [GeV]"                         , "# events (2018)"   ),
-  # Histogram("GoodMediumBtaggedJets_eta"           , "", False,  True  , default_norm              , 5  , -3.5  , 3.5   , 1e0   , 1e10  , "good b-jet #eta"                                , "# events (2018)"   ),
+  Histogram("GoodMediumBtaggedJets_pt"            , "", False,  True  , default_norm              , 20 , 0     , 2000  , 1e-3   , 1e6   , "good b-jet p_{T} [GeV]"                         , "# events (2018)"   ),
+  Histogram("GoodMediumBtaggedJets_eta"           , "", False,  True  , default_norm              , 5  , -3.5  , 3.5   , 1e-3   , 1e6   , "good b-jet #eta"                                , "# events (2018)"   ),
   # Histogram("GoodMediumBtaggedJets_btagDeepB"     , "", False,  True  , default_norm              , 10 , -1    , 1     , 1e0   , 1e8   , "good b-jet deepCSV score"                       , "# events (2018)"   ),
   # Histogram("GoodMediumBtaggedJets_btagDeepFlavB" , "", False,  True  , default_norm              , 10 , -1    , 1     , 1e0   , 1e8   , "good b-jet deepJet score"                       , "# events (2018)"   ),
   
@@ -218,7 +226,7 @@ histograms = (
   # Primary vertices
   # ----------------------------------------------------------------------------
   Histogram("Event_PV_npvs"                       , "", False,  True  , default_norm              , 1  , 0     , 150   , 1e-3  , 1e12  , "# Primary vertices"                             , "# events (2018)"   ),
-  Histogram("Event_PV_npvsGood"                   , "", False,  True  , default_norm              , 1  , 0     , 150   , 1e-3  , 1e6   , "# Good primary vertices"                        , "# events (2018)"   ),
+  Histogram("Event_PV_npvsGood"                   , "", False,  True  , default_norm              , 1  , 0     , 80   , 1e-4  , 1e8   , "# Good primary vertices"                        , "# events (2018)"   ),
   Histogram("Event_PV_x"                          , "", False, True   , default_norm              , 1  , 0     , 20   , 1e-2   , 1e8   , "PV x [cm]"                                      , "# events (2018)"   ),
   Histogram("Event_PV_y"                          , "", False, True   , default_norm              , 1  , 0     , 20   , 1e-2   , 1e8   , "PV y [cm]"                                      , "# events (2018)"   ),
   Histogram("Event_PV_z"                          , "", False, True   , default_norm              , 1  , 0     , 20   , 1e-2   , 1e8   , "PV z [cm]"                                      , "# events (2018)"   ),
@@ -245,15 +253,16 @@ elif skim[1] == "_ZDimuons":
 for collection, category in product(extraMuonVertexCollections, ("","_PatDSA", "_DSA", "_Pat")):
   histograms += (
     Histogram("Event_n"+collection + category                          , "", False, True  , default_norm            , 1           , 0         , 5         , 1e-3  , 1e8   , "Number of loose #mu vertices"             , "# events (2018)" ),
-    Histogram(collection + category+"_invMass"                         , "", False, False , default_norm            , mass_rebin  , mass_min  , mass_max  , 0     , 1500  , "#mu vertex M_{#mu #mu} [GeV]"             , "# events (2018)" ),
-    Histogram(collection + category+"_logInvMass"                      , "", False, True  , default_norm            , 1           , 0.45      , 0.53      , 1e-2  , 1e6   , "#mu vertex log_{10}(M_{#mu #mu} [GeV])"   , "# events (2018)" ),
+    Histogram(collection + category+"_invMass"                         , "", False, False , default_norm            , mass_rebin  , mass_min  , mass_max  , 0     , 300   , "#mu vertex M_{#mu #mu} [GeV]"             , "# events (2018)" ),
+    Histogram(collection + category+"_logInvMass"                      , "", False, True  , default_norm            , 10          , -1        , 2         , 1e-5  , 1e3   , "#mu vertex log_{10}(M_{#mu #mu} [GeV])"   , "# events (2018)" ),
     Histogram(collection + category+"_eta"                             , "", False, True  , default_norm            , 5           , -3.5      , 3.5       , 1e-3  , 1e6   , "#mu vertex p_{T} [GeV]"                   , "# events (2018)" ),
     Histogram(collection + category+"_pt"                              , "", False, True  , default_norm            , 10          , 0         , 200       , 1e-3  , 1e6   , "#mu vertex p_{T} [GeV]"                   , "# events (2018)" ),
     Histogram(collection + category+"_leadingPt"                       , "", False, True  , default_norm            , 5           , 0         , 200       , 1e-3  , 1e6   , "#mu vertex leading p_{T} [GeV]"           , "# events (2018)" ),
     
-    Histogram(collection + category+"_LxySignificance"                 , "", False, True  , default_norm            , 2           , 0         , 200       , 1e-3  , 1e6   , "#mu vertex L_{xy} / #sigma_{Lxy}"         , "# events (2018)" ),
-    Histogram(collection + category+"_Lxy"                             , "", False, True  , default_norm            , 1           , 0         , 20        , 1e-10 , 1e6   , "#mu vertex L_{xy} [cm]"                   , "# events (2018)" ),
-    Histogram(collection + category+"_LxySigma"                        , "", False, True  , default_norm            , 1           , 0         , 1         , 1e-3  , 1e6   , "#mu vertex #sigma_{Lxy} [cm]"             , "# events (2018)" ),
+    Histogram(collection + category+"_LxySignificance"                 , "", False, True  , default_norm            , 10           , 0         , 100       , 1e-3  , 1e6   , "#mu vertex L_{xy} / #sigma_{Lxy}"         , "# events (2018)" ),
+    Histogram(collection + category+"_Lxy"                             , "", False, True  , default_norm            , 20          , 0         , 300       , 1e-8  , 1e7   , "#mu vertex L_{xy} [cm]"                   , "# events (2018)" ),
+    Histogram(collection + category+"_logLxy"                          , "", False, True  , default_norm            , 10          , -4        , 3         , 1e-8  , 1e7   , "#mu vertex L_{xy} [cm]"                   , "# events (2018)" ),
+    Histogram(collection + category+"_LxySigma"                        , "", False, True  , default_norm            , 1           , 0         , 2         , 1e-3  , 1e6   , "#mu vertex #sigma_{Lxy} [cm]"             , "# events (2018)" ),
     
     # Histogram(collection + category+"_normChi2"                        , "", False, True  , default_norm            , 100         , 0         , 5         , 1e-5  , 1e4   , "#mu vertex #chi^{2}/ndof"                 , "# events (2018)" ),
     # Histogram(collection + category+"_maxHitsInFrontOfVert"            , "", False, True  , default_norm            , 1           , 0         , 35        , 1e-6  , 1e6   , "Max N(hits before vertex)"                , "# events (2018)" ),

--- a/configs/ttalps_plotter_config.py
+++ b/configs/ttalps_plotter_config.py
@@ -18,8 +18,8 @@ luminosity = get_luminosity(year)
 base_path = f"/data/dust/user/{os.environ['USER']}/ttalps_cms/"
 
 # skim = ("skimmed_looseSemimuonic_v2_ttbarCR", "")
-# skim = ("skimmed_looseSemimuonic_v2_SR", "_SRDimuons")
-skim = ("skimmed_looseSemimuonic_v2_SR", "_JPsiDimuons")
+skim = ("skimmed_looseSemimuonic_v2_SR", "_SRDimuons")
+# skim = ("skimmed_looseSemimuonic_v2_SR", "_JPsiDimuons")
 # skim = ("skimmed_looseSemimuonic_v2_SR", "_ZDimuons")
 # skim = ("skimmed_looseNonTT_v1_QCDCR", "_SRDimuons")  # this is in fact VV CR
 # skim = ("skimmed_looseNoBjets_lt4jets_v1_QCDCR", "_SRDimuons")
@@ -57,6 +57,7 @@ extraMuonVertexCollections = [
   # "MaskedDimuonVerex",      # invariant mass cut only
   "BestDimuonVertex",       # best Dimuon selection without isolation cut
   # "BestPFIsoDimuonVertex",  # best Dimuon selection with isolation cut
+  # "BestPFIsoDimuonVertexNminus1",  # best Dimuon selection with isolation cut
 ]
 
 # Gen-level resonances plots - comment out to avoid plots for these collections 
@@ -130,11 +131,10 @@ histograms = (
   # Event variables
   # ----------------------------------------------------------------------------
   Histogram("cutFlow"                              , "", False,  True  , default_norm              , 1  , 0     , 12    , 1e1   , 1e15  , "Selection"                                      , "Number of events"  ),
-  Histogram("dimuonCutFlow_BestDimuonVertex"       , "", False,  True  , default_norm              , 1  , 0     , 10    , 1e3   , 4e3   , "Selection"                                      , "Number of events"  ),
-  Histogram("dimuonCutFlow_BestDimuonVertex_Pat"   , "", False,  True  , default_norm              , 1  , 0     , 10    , 2e2   , 1e4   , "Selection"                                      , "Number of events"  ),
-  Histogram("dimuonCutFlow_BestDimuonVertex_PatDSA", "", False,  True  , default_norm              , 1  , 0     , 10    , 1e1   , 1e4   , "Selection"                                      , "Number of events"  ),
-  Histogram("dimuonCutFlow_BestDimuonVertex_DSA"   , "", False,  True  , default_norm              , 1  , 0     , 10    , 1e-1  , 1e4   , "Selection"                                      , "Number of events"  ),
-  Histogram("dimuonCutFlow_BestDimuonVertex"       , "", False,  True  , default_norm              , 1  , 0     , 8     , 1e-1  , 1e2   , "Selection"                                      , "Number of events"  ),
+  Histogram("dimuonCutFlow_BestDimuonVertex"       , "", False,  True  , default_norm              , 1  , 0     , 10    , 1e2   , 1e7   , "Selection"                                      , "Number of events"  ),
+  Histogram("dimuonCutFlow_BestDimuonVertex_Pat"   , "", False,  True  , default_norm              , 1  , 0     , 10    , 2e2   , 1e7   , "Selection"                                      , "Number of events"  ),
+  Histogram("dimuonCutFlow_BestDimuonVertex_PatDSA", "", False,  True  , default_norm              , 1  , 0     , 10    , 1e2   , 1e7   , "Selection"                                      , "Number of events"  ),
+  Histogram("dimuonCutFlow_BestDimuonVertex_DSA"   , "", False,  True  , default_norm              , 1  , 0     , 10    , 1e-1  , 1e7   , "Selection"                                      , "Number of events"  ),
   Histogram("Event_normCheck"                      , "", False,  True  , default_norm              , 1  , 0     , 1     , 1e-2  , 1e7   , "norm check"                                     , "# events (2018)"   ),
   Histogram("Event_isData"                         , "", False,  True  , default_norm              , 1  , 0     , 2     , 1e-8  , 1e7   , "Is Data Event"                                  , "# events (2018)"   ),
   Histogram("Event_MET_pt"                         , "", False,  True  , default_norm              , 10 , 0     , 800   , 1e-8  , 1e9   , "MET p_{T} [GeV]"                                , "# events (2018)"   ),
@@ -180,6 +180,9 @@ histograms = (
   # Histogram("LooseMuonsSegmentMatch_jetRelIso"             , "", False,  True  , default_norm              , 50 , -1    , 8.0   , 1e-2  , 1e6   , "Loose #mu jet Rel Iso"                          , "# events (2018)"   ),
   # Histogram("LooseMuonsSegmentMatch_tkRelIso"              , "", False,  True  , default_norm              , 20 , -0.1  , 8.0   , 1e-2  , 1e6   , "Loose #mu track Rel Iso"                        , "# events (2018)"   ),
   
+    # Histogram("LooseMuonsVertexSegmentMatch_3Dangle"       , "", False, True  , default_norm               , 2           , 0          , 3.15      , 1e-4  , 1e8   , "#mu vertex 3Dangle"                       , "# events (2018)" ),
+    # Histogram("LooseMuonsVertexSegmentMatch_cos3Dangle"    , "", False, True  , default_norm               , 2           , -1         , 1         , 1e-4  , 1e8   , "#mu vertex cos 3Dangle"                       , "# events (2018)" ),
+
   # ----------------------------------------------------------------------------
   # Loose DSA muons
   # ----------------------------------------------------------------------------
@@ -232,9 +235,9 @@ histograms = (
 # ----------------------------------------------------------------------------
 
 if skim[1] == "_SRDimuons":
-  mass_rebin = 1
+  mass_rebin = 10
   mass_min = 0.0
-  mass_max = 100.0
+  mass_max = 10.0
 elif skim[1] == "_JPsiDimuons":
   mass_rebin = 1
   mass_min = 2.8
@@ -247,34 +250,35 @@ elif skim[1] == "_ZDimuons":
 for collection, category in product(extraMuonVertexCollections, ("","_PatDSA", "_DSA", "_Pat")):
   histograms += (
     Histogram("Event_n"+collection + category                          , "", False, True  , default_norm            , 1           , 0         , 5         , 1e-3  , 1e8   , "Number of loose #mu vertices"             , "# events (2018)" ),
-    Histogram(collection + category+"_invMass"                         , "", False, False , default_norm            , mass_rebin  , mass_min  , mass_max  , 0     , 300   , "#mu vertex M_{#mu #mu} [GeV]"             , "# events (2018)" ),
+    Histogram(collection + category+"_invMass"                         , "", False, True  , default_norm            , mass_rebin  , mass_min  , mass_max  , 1e-3  , 1e3   , "#mu vertex M_{#mu #mu} [GeV]"             , "# events (2018)" ),
     Histogram(collection + category+"_logInvMass"                      , "", False, True  , default_norm            , 10          , -1        , 2         , 1e-5  , 1e3   , "#mu vertex log_{10}(M_{#mu #mu} [GeV])"   , "# events (2018)" ),
-    Histogram(collection + category+"_eta"                             , "", False, True  , default_norm            , 5           , -3.5      , 3.5       , 1e-3  , 1e6   , "#mu vertex p_{T} [GeV]"                   , "# events (2018)" ),
+    Histogram(collection + category+"_eta"                             , "", False, True  , default_norm            , 5           , -3.5      , 3.5       , 1e-3  , 1e8   , "#mu vertex #eta"                   , "# events (2018)" ),
     Histogram(collection + category+"_pt"                              , "", False, True  , default_norm            , 10          , 0         , 200       , 1e-3  , 1e6   , "#mu vertex p_{T} [GeV]"                   , "# events (2018)" ),
     Histogram(collection + category+"_leadingPt"                       , "", False, True  , default_norm            , 5           , 0         , 200       , 1e-3  , 1e6   , "#mu vertex leading p_{T} [GeV]"           , "# events (2018)" ),
-    
-    Histogram(collection + category+"_LxySignificance"                 , "", False, True  , default_norm            , 10           , 0         , 100       , 1e-3  , 1e6   , "#mu vertex L_{xy} / #sigma_{Lxy}"         , "# events (2018)" ),
-    Histogram(collection + category+"_Lxy"                             , "", False, True  , default_norm            , 20          , 0         , 300       , 1e-8  , 1e7   , "#mu vertex L_{xy} [cm]"                   , "# events (2018)" ),
-    Histogram(collection + category+"_logLxy"                          , "", False, True  , default_norm            , 10          , -4        , 3         , 1e-8  , 1e7   , "#mu vertex L_{xy} [cm]"                   , "# events (2018)" ),
+    Histogram(collection + category+"_subleadingPt"                    , "", False, True  , default_norm            , 5           , 0         , 200       , 1e-3  , 1e6   , "#mu vertex subleading p_{T} [GeV]"        , "# events (2018)" ),
+    Histogram(collection + category+"_leadingEta"                      , "", False, True  , default_norm            , 5           , -3.5      , 3.5       , 1e-3  , 1e8   , "#mu vertex leading #eta"                  , "# events (2018)" ),
+    Histogram(collection + category+"_subleadingEta"                   , "", False, True  , default_norm            , 5           , -3.5      , 3.5       , 1e-3  , 1e8   , "#mu vertex subleading #eta"               , "# events (2018)" ),
+
+    Histogram(collection + category+"_LxySignificance"                 , "", False, True  , default_norm            , 10           , 0         , 250       , 1e-7  , 1e5   , "#mu vertex L_{xy} / #sigma_{Lxy}"         , "# events (2018)" ),
+    Histogram(collection + category+"_Lxy"                             , "", False, True  , default_norm            , 300          , 0         , 800       , 1e-7  , 1e5   , "#mu vertex L_{xy} [cm]"                   , "# events (2018)" ),
+    Histogram(collection + category+"_logLxy"                          , "", False, False  , default_norm            , 10          , -4        , 3         , 0  , 500   , "#mu vertex L_{xy} [cm]"                   , "# events (2018)" ),
     Histogram(collection + category+"_LxySigma"                        , "", False, True  , default_norm            , 1           , 0         , 2         , 1e-3  , 1e6   , "#mu vertex #sigma_{Lxy} [cm]"             , "# events (2018)" ),
     
     # Histogram(collection + category+"_normChi2"                        , "", False, True  , default_norm            , 100         , 0         , 5         , 1e-5  , 1e4   , "#mu vertex #chi^{2}/ndof"                 , "# events (2018)" ),
     # Histogram(collection + category+"_maxHitsInFrontOfVert"            , "", False, True  , default_norm            , 1           , 0         , 35        , 1e-6  , 1e6   , "Max N(hits before vertex)"                , "# events (2018)" ),
     # Histogram(collection + category+"_dca"                             , "", False, True  , default_norm            , 10          , 0         , 10        , 1e-6  , 1e6   , "DCA [cm]"                                 , "# events (2018)" ),
     # Histogram(collection + category+"_absCollinearityAngle"            , "", False, True  , default_norm            , 10          , 0         , 3.15      , 1e-6  , 1e6   , "#mu vertex |#Delta #Phi|"                 , "# events (2018)" ),
+    # Histogram(collection + category+"_3Dangle"                         , "", False, True  , default_norm            , 2           , 0         , 3.15      , 1e-5  , 1e7   , "#mu vertex 3Dangle"                       , "# events (2018)" ),
+    # Histogram(collection + category+"_cos3Dangle"                      , "", False, True  , default_norm            , 2           , -1        , 1         , 1e-5  , 1e7   , "#mu vertex cos 3Dangle"                       , "# events (2018)" ),
     # Histogram(collection + category+"_absPtLxyDPhi1"                   , "", False, True  , default_norm            , 10          , 0         , 3.15      , 1e-4  , 1e5   , "#mu vertex |#Delta #phi_{#mu1}|"          , "# events (2018)" ),
     # Histogram(collection + category+"_pfRelIso04all1"                  , "", False, True  , default_norm            , 4           , 0         , 10        , 1e-3  , 1e6   , "#mu_{1} I_{PF}^{rel} ( #Delta R < 0.4 )"  , "# events (2018)" ),
     # Histogram(collection + category+"_pfRelIso04all2"                  , "", False, True  , default_norm            , 4           , 0         , 10        , 1e-3  , 1e6   , "#mu_{2} I_{PF}^{rel} ( #Delta R < 0.4 )"  , "# events (2018)" ),
-  )
-  histograms2D += (
-    Histogram2D(collection + category+"_log3Dangle_logLxySignificance",  "",  False,  False,  True,  NormalizationType.to_lumi, 4, 4, -3, 1, -2,  20, 1e-3,  1e2,  "#mu vertex #alpha",  "#mu vertex L_{xy} / #sigma_{Lxy}",   "# events (2018)",  ""  ),
+    # Histogram(collection + category+"_chargeProduct"                   , "", False, True  , default_norm            , 1           , 0         , 2          , 1e-6  , 1e6   , "#mu vertex charge"                       , "# events (2018)" ),
+
   )
   
 for collection in genMuonVertexCollections:
   for category in ["_PatDSA", "_DSA", "_Pat"]:
     histograms += (
       Histogram("Event_n"+collection + category                     , "", False, True  , default_norm     , 1  , 0     , 5     , 1e-3  , 1e6   , "Number of #mu vertices"            , "# events (2018)" ),
-    )
-    histograms2D += (
-      Histogram2D(collection + category+"_log3Dangle_logLxySignificance",  "",  False,  False,  True,  NormalizationType.to_lumi, 4, 4, -3, 1, -2,  20, 1e-3,  1e2,  "#mu vertex #alpha",  "#mu vertex L_{xy} / #sigma_{Lxy}",   "# events (2018)",  ""  ),
     )

--- a/configs/ttalps_plotting_styles_SR.py
+++ b/configs/ttalps_plotting_styles_SR.py
@@ -60,7 +60,11 @@ samples_params = {
 
     "tta_mAlp-0p35GeV_ctau-1e2mm": {"color": ROOT.kGreen+1, "legend_column": 0, "legend_row": 1, "legend_title": "0.35 GeV, 1e5 mm"},
     "tta_mAlp-0p35GeV_ctau-1e3mm": {"color": ROOT.kRed+1  , "legend_column": 0, "legend_row": 2, "legend_title": "0.35 GeV, 1e3 mm"},
-    "tta_mAlp-0p35GeV_ctau-1e5mm": {"color": ROOT.kRed+3  , "legend_column": 0, "legend_row": 3, "legend_title": "0.35 GeV, 1e5 mm"}
+    "tta_mAlp-0p35GeV_ctau-1e5mm": {"color": ROOT.kRed+3  , "legend_column": 0, "legend_row": 3, "legend_title": "0.35 GeV, 1e5 mm"},
+
+    "tta_mAlp-2GeV_ctau-1e0mm": {"color": ROOT.kGreen+1, "legend_column": 0, "legend_row": 1, "legend_title": "2 GeV, 1 mm"},
+    "tta_mAlp-2GeV_ctau-1e1mm": {"color": ROOT.kRed+1  , "legend_column": 0, "legend_row": 2, "legend_title": "2 GeV, 1 cm"},
+    "tta_mAlp-2GeV_ctau-1e2mm": {"color": ROOT.kRed+3  , "legend_column": 0, "legend_row": 3, "legend_title": "2 GeV, 10 cm"}
 }
 
 

--- a/configs/ttalps_skimmer_looseSemimuonic_config.py
+++ b/configs/ttalps_skimmer_looseSemimuonic_config.py
@@ -1,10 +1,12 @@
 from ttalps_extra_collections import *
 from golden_json_config import goldenJsons
+from ttalps_met_filters import *
 
 year = "2018"
 # options for year is: 2016preVFP, 2016postVFP, 2017, 2018, 2022preEE, 2022postEE, 2023preBPix, 2023postBPix
 goldenJson = goldenJsons[year]
 extraEventCollections = get_extra_event_collections(year)
+met_filters = get_met_filters(year)
 
 nEvents = -1
 printEveryNevents = 10000
@@ -26,18 +28,7 @@ eventCuts = {
     "nGoodMediumBtaggedJets": (1, 9999999),
 }
 
-requiredFlags = (
-    "Flag_goodVertices",
-    "Flag_globalSuperTightHalo2016Filter",
-    "Flag_HBHENoiseFilter",
-    "Flag_HBHENoiseIsoFilter",
-    "Flag_EcalDeadCellTriggerPrimitiveFilter",
-    "Flag_BadPFMuonFilter",
-    "Flag_BadPFMuonDzFilter",
-    "Flag_hfNoisyHitsFilter",
-    "Flag_eeBadScFilter",
-    "Flag_ecalBadCalibFilter",
-)
+requiredFlags = met_filters
 
 branchesToKeep = ["*"]
 branchesToRemove = []

--- a/configs/ttalps_skimmer_looseSemimuonic_config.py
+++ b/configs/ttalps_skimmer_looseSemimuonic_config.py
@@ -1,12 +1,11 @@
 from ttalps_extra_collections import *
 from golden_json_config import goldenJsons
-from ttalps_met_filters import *
+from ttalps_met_filters import get_met_filters
 
 year = "2018"
 # options for year is: 2016preVFP, 2016postVFP, 2017, 2018, 2022preEE, 2022postEE, 2023preBPix, 2023postBPix
 goldenJson = goldenJsons[year]
 extraEventCollections = get_extra_event_collections(year)
-met_filters = get_met_filters(year)
 
 nEvents = -1
 printEveryNevents = 10000
@@ -28,7 +27,7 @@ eventCuts = {
     "nGoodMediumBtaggedJets": (1, 9999999),
 }
 
-requiredFlags = met_filters
+requiredFlags = get_met_filters(year)
 
 branchesToKeep = ["*"]
 branchesToRemove = []

--- a/libs/user_extensions/include/TTAlpsEvent.hpp
+++ b/libs/user_extensions/include/TTAlpsEvent.hpp
@@ -23,6 +23,8 @@ class TTAlpsEvent {
   std::map<std::string,float> GetEventWeights();
 
   std::shared_ptr<NanoMuons> GetAllLooseMuons();
+
+  // returns 2 muons from the dimuon vertex (if there is one), and the leading remaining muon
   std::shared_ptr<NanoMuons> GetTTAlpsEventMuons();
 
   std::shared_ptr<PhysicsObjects> GetGenALPs();

--- a/libs/user_extensions/include/TTAlpsEvent.hpp
+++ b/libs/user_extensions/include/TTAlpsEvent.hpp
@@ -4,10 +4,12 @@
 #include "Event.hpp"
 #include "NanoEvent.hpp"
 #include "Helpers.hpp"
+#include "EventProcessor.hpp"
+#include "NanoEventProcessor.hpp"
 
 class TTAlpsEvent {
  public:
-  TTAlpsEvent(std::shared_ptr<Event> event_) : event(event_) {}
+  TTAlpsEvent(std::shared_ptr<Event> event_);
 
   auto Get(std::string branchName, const char* file = __builtin_FILE(), const char* function = __builtin_FUNCTION(),
            int line = __builtin_LINE()) {
@@ -18,6 +20,12 @@ class TTAlpsEvent {
   T GetAs(std::string branchName) { return event->GetAs<T>(branchName); }
   std::shared_ptr<PhysicsObjects> GetCollection(std::string name) const { return event->GetCollection(name); }
   
+  std::map<std::string,float> GetEventWeights();
+  bool IsDataEvent();
+
+  std::shared_ptr<NanoMuons> GetAllLooseMuons();
+  std::shared_ptr<NanoMuons> GetTTAlpsEventMuons();
+
   std::shared_ptr<PhysicsObjects> GetGenALPs();
   std::shared_ptr<MuonPair> GetGenDimuonFromALP();
   std::vector<int> GetGenMuonIndicesFromALP();
@@ -53,6 +61,11 @@ class TTAlpsEvent {
 
  private:
   std::shared_ptr<Event> event;
+  std::unique_ptr<EventProcessor> eventProcessor;
+  std::unique_ptr<NanoEventProcessor> nanoEventProcessor;
+  std::string weightsBranchName;
+  std::map<std::string, float> muonMatchingParams;
+  std::pair<std::string, std::vector<std::string>> muonVertexCollection;
 
   std::vector<int> GetTopIndices();
   std::vector<int> GetBottomIndices();

--- a/libs/user_extensions/include/TTAlpsEvent.hpp
+++ b/libs/user_extensions/include/TTAlpsEvent.hpp
@@ -22,9 +22,10 @@ class TTAlpsEvent {
   
   std::map<std::string,float> GetEventWeights();
 
+  // returns all Loose (PAT and DSA) muons in the event. If matchingParams are defined it returns the collection after the first matching
   std::shared_ptr<NanoMuons> GetAllLooseMuons();
 
-  // returns 2 muons from the dimuon vertex (if there is one), and the leading remaining muon
+  // returns 2 muons from the dimuon vertex (if there is one defined in the config), and the leading remaining muon
   std::shared_ptr<NanoMuons> GetTTAlpsEventMuons();
 
   std::shared_ptr<PhysicsObjects> GetGenALPs();

--- a/libs/user_extensions/include/TTAlpsEvent.hpp
+++ b/libs/user_extensions/include/TTAlpsEvent.hpp
@@ -21,7 +21,6 @@ class TTAlpsEvent {
   std::shared_ptr<PhysicsObjects> GetCollection(std::string name) const { return event->GetCollection(name); }
   
   std::map<std::string,float> GetEventWeights();
-  bool IsDataEvent();
 
   std::shared_ptr<NanoMuons> GetAllLooseMuons();
   std::shared_ptr<NanoMuons> GetTTAlpsEventMuons();

--- a/libs/user_extensions/include/TTAlpsHistogramFiller.hpp
+++ b/libs/user_extensions/include/TTAlpsHistogramFiller.hpp
@@ -21,6 +21,7 @@ class TTAlpsHistogramFiller {
   void FillCustomTTAlpsMuonMatchingVariables(const std::shared_ptr<Event> event);
 
   void FillNormCheck(const std::shared_ptr<Event> event);
+  void FillDataCheck(const std::shared_ptr<Event> event);
 
   void FillDimuonCutFlows(const std::shared_ptr<CutFlowManager> cutFlowManager, std::string dimuonCategory = "");
 
@@ -47,11 +48,8 @@ class TTAlpsHistogramFiller {
   std::vector<std::string> triggerNames;
   bool EndsWithTriggerName(std::string name);
 
-  float GetEventWeight(const std::shared_ptr<Event> event);
-  float GetObjectWeight(const std::shared_ptr<PhysicsObject> object, std::string collectionName);
-
   // Loose Muons and Loose muon vertex histograms
-  void FillLooseMuonsHistograms(const std::shared_ptr<NanoMuons> muons, std::string collectionName, float weight);
+  void FillLooseMuonsHistograms(const std::shared_ptr<NanoMuons> muons, std::string collectionName);
   void FillLooseMuonsHistograms(const std::shared_ptr<Event> event, std::string collectionName);
   void FillMuonVertexHistograms(const std::shared_ptr<Event> event,
                                 const std::shared_ptr<Collection<std::shared_ptr<PhysicsObject>>> vertexCollection, std::string vertexName);
@@ -61,8 +59,7 @@ class TTAlpsHistogramFiller {
   void FillNminus1HistogramsForMuonVertexCollection(const std::shared_ptr<Event> event);
 
   // Nminus1 LLPnanoAOD histograms
-  void FillDimuonVertexNminus1HistogramForCut(std::string collectionName, std::string cut, std::shared_ptr<NanoDimuonVertex> dimuonVertex,
-                                              float weight);
+  void FillDimuonVertexNminus1HistogramForCut(std::string collectionName, std::string cut, std::shared_ptr<NanoDimuonVertex> dimuonVertex);
 
   // Gen-Level histograms
   void FillGenALPsHistograms(const std::shared_ptr<Event> event);
@@ -73,7 +70,7 @@ class TTAlpsHistogramFiller {
 
   void FillGenDimuonHistograms(std::shared_ptr<MuonPair> muonPair, std::string collectionName, const std::shared_ptr<Event> event);
   void FillGenMuonMinDRHistograms(const std::shared_ptr<PhysicsObject> genMuon, const std::shared_ptr<NanoMuons> muonCollection,
-                                  std::string genMuonCollectionName, std::string looseMuonCollectionName, float weight);
+                                  std::string genMuonCollectionName, std::string looseMuonCollectionName);
   void FillRecoGenMatchedResonanceHistograms(const std::shared_ptr<Event> event, const std::shared_ptr<NanoMuons> muonCollection,
                                              std::string collectionName, const std::shared_ptr<PhysicsObjects> vertexCollection = nullptr);
 
@@ -81,7 +78,7 @@ class TTAlpsHistogramFiller {
   void FillMuonCollectionFromALPsNminus1Histograms(const std::shared_ptr<Event> event);
 
   // Muon Matching histograms
-  void FillMatchedMuonHistograms(const std::shared_ptr<NanoMuon> muon, std::string muonCollectionName, float weight);
+  void FillMatchedMuonHistograms(const std::shared_ptr<NanoMuon> muon, std::string muonCollectionName);
   void FillMatchingHistograms(const std::shared_ptr<Event> event, std::string patMuonCollection, std::string dsaMuonCollection);
 };
 

--- a/libs/user_extensions/include/TTAlpsHistogramFiller.hpp
+++ b/libs/user_extensions/include/TTAlpsHistogramFiller.hpp
@@ -20,7 +20,7 @@ class TTAlpsHistogramFiller {
   void FillCustomTTAlpsGenMuonVariables(const std::shared_ptr<Event> event);
   void FillCustomTTAlpsMuonMatchingVariables(const std::shared_ptr<Event> event);
 
-  void FillNormCheck(const std::shared_ptr<Event> event);
+  void FillNormCheck();
   void FillDataCheck(const std::shared_ptr<Event> event);
 
   void FillDimuonCutFlows(const std::shared_ptr<CutFlowManager> cutFlowManager, std::string dimuonCategory = "");

--- a/libs/user_extensions/include/TTAlpsHistogramFiller.hpp
+++ b/libs/user_extensions/include/TTAlpsHistogramFiller.hpp
@@ -51,11 +51,11 @@ class TTAlpsHistogramFiller {
   // Loose Muons and Loose muon vertex histograms
   void FillLooseMuonsHistograms(const std::shared_ptr<NanoMuons> muons, std::string collectionName);
   void FillLooseMuonsHistograms(const std::shared_ptr<Event> event, std::string collectionName);
-  void FillLooseMuonsHistograms(const std::shared_ptr<NanoMuon> muon, std::string name, float weight);
+  void FillLooseMuonsHistograms(const std::shared_ptr<NanoMuon> muon, std::string name);
   
   void FillMuonVertexHistograms(const std::shared_ptr<Event> event, const std::shared_ptr<PhysicsObjects> vertexCollection, std::string vertexName);
   void FillMuonVertexHistograms(const std::shared_ptr<Event> event, std::string vertexName);
-  void FillMuonVertexHistograms(const std::shared_ptr<NanoDimuonVertex> dimuon, std::string name, float weight);
+  void FillMuonVertexHistograms(const std::shared_ptr<NanoDimuonVertex> dimuon, std::string name);
 
   // Dimuon Vertex Collection Histograms
   void FillNminus1HistogramsForMuonVertexCollection(const std::shared_ptr<Event> event);

--- a/libs/user_extensions/src/TTAlpsEvent.cpp
+++ b/libs/user_extensions/src/TTAlpsEvent.cpp
@@ -49,7 +49,7 @@ map<string,float> TTAlpsEvent::GetEventWeights() {
   // if (year == "2018") pileupSF = nanoEventProcessor->GetPileupScaleFactor(nanoEvent, "custom"); // TODO: do we want to use custom for all years?
   // else pileupSF = nanoEventProcessor->GetPileupScaleFactor(nanoEvent, "pileup");
   pileupSF = nanoEventProcessor->GetPileupScaleFactor(nanoEvent, "custom");
-  float muonTriggerSF = nanoEventProcessor->GetMuonTriggerScaleFactor(nanoEvent, "muonTriggerIsoMu24");
+  map<string,float> muonTriggerSF = nanoEventProcessor->GetMuonTriggerScaleFactor(nanoEvent, "muonTriggerIsoMu24");
 
   int maxNjets = 4;
   auto leadingJets = eventProcessor->GetLeadingObjects(event, "GoodJets", maxNjets);
@@ -67,13 +67,17 @@ map<string,float> TTAlpsEvent::GetEventWeights() {
   auto muons = GetTTAlpsEventMuons();
   map<string,float> muonSF = nanoEventProcessor->GetMuonScaleFactors(muons);
   
-  scaleFactorMap["central"] = genWeight * pileupSF * muonTriggerSF * btagSF["central"] * PUjetIDSF["central"] * muonSF["central"];
-  scaleFactorMap["btagUpCorrelated"] = genWeight * pileupSF * muonTriggerSF * btagSF["upCorrelated"] * PUjetIDSF["central"] * muonSF["central"];
-  scaleFactorMap["btagDownCorrelated"] = genWeight * pileupSF * muonTriggerSF * btagSF["downCorrelated"] * PUjetIDSF["central"] * muonSF["central"];
-  scaleFactorMap["btagUpUncorrelated"] = genWeight * pileupSF * muonTriggerSF * btagSF["upUncorrelated"] * PUjetIDSF["central"] * muonSF["central"];
-  scaleFactorMap["btagDownUncorrelated"] = genWeight * pileupSF * muonTriggerSF * btagSF["downUncorrelated"] * PUjetIDSF["central"] * muonSF["central"];
-  scaleFactorMap["pujetIDUp"] = genWeight * pileupSF * muonTriggerSF * btagSF["central"] * PUjetIDSF["up"] * muonSF["central"];
-  scaleFactorMap["pujetIDdown"] = genWeight * pileupSF * muonTriggerSF * btagSF["central"] * PUjetIDSF["down"] * muonSF["central"];
+  scaleFactorMap["central"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["central"] * PUjetIDSF["central"] * muonSF["central"];
+  scaleFactorMap["btagUpCorrelated"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["upCorrelated"] * PUjetIDSF["central"] * muonSF["central"];
+  scaleFactorMap["btagDownCorrelated"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["downCorrelated"] * PUjetIDSF["central"] * muonSF["central"];
+  scaleFactorMap["btagUpUncorrelated"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["upUncorrelated"] * PUjetIDSF["central"] * muonSF["central"];
+  scaleFactorMap["btagDownUncorrelated"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["downUncorrelated"] * PUjetIDSF["central"] * muonSF["central"];
+  scaleFactorMap["pujetIDUp"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["central"] * PUjetIDSF["up"] * muonSF["central"];
+  scaleFactorMap["pujetIDdown"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["central"] * PUjetIDSF["down"] * muonSF["central"];
+  scaleFactorMap["muonUp"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["central"] * PUjetIDSF["central"] * muonSF["up"];
+  scaleFactorMap["muonDown"] = genWeight * pileupSF * muonTriggerSF["central"] * btagSF["central"] * PUjetIDSF["central"] * muonSF["down"];
+  scaleFactorMap["muonTriggerUp"] = genWeight * pileupSF * muonTriggerSF["up"] * btagSF["central"] * PUjetIDSF["central"] * muonSF["central"];
+  scaleFactorMap["muonTriggerDown"] = genWeight * pileupSF * muonTriggerSF["down"] * btagSF["central"] * PUjetIDSF["central"] * muonSF["central"];
   
   return scaleFactorMap;
 }

--- a/libs/user_extensions/src/TTAlpsEvent.cpp
+++ b/libs/user_extensions/src/TTAlpsEvent.cpp
@@ -45,14 +45,14 @@ map<string,float> TTAlpsEvent::GetEventWeights() {
   auto leadingJets = eventProcessor->GetLeadingObjects(event, "GoodJets", maxNjets);
   map<string,float> PUjetIDSF = nanoEventProcessor->GetPUJetIDScaleFactors(asNanoJets(leadingJets));
 
-  auto leadingbJets = make_shared<NanoJets>();
+  auto leadingBJets = make_shared<NanoJets>();
   auto allBJets = event->GetCollection("GoodMediumBtaggedJets");
   for (auto jet : *leadingJets) {
     for (auto bJet : *allBJets) {
-      if (jet == bJet) leadingbJets->push_back(asNanoJet(jet));
+      if (jet == bJet) leadingBJets->push_back(asNanoJet(jet));
     }
   }
-  map<string,float> btagSF = nanoEventProcessor->GetMediumBTaggingScaleFactors(leadingbJets);
+  map<string,float> btagSF = nanoEventProcessor->GetMediumBTaggingScaleFactors(leadingBJets);
 
   auto muons = GetTTAlpsEventMuons();
   map<string,float> muonSF = nanoEventProcessor->GetMuonScaleFactors(muons);

--- a/libs/user_extensions/src/TTAlpsEvent.cpp
+++ b/libs/user_extensions/src/TTAlpsEvent.cpp
@@ -39,7 +39,7 @@ map<string,float> TTAlpsEvent::GetEventWeights() {
   // if (year == "2018") pileupSF = nanoEventProcessor->GetPileupScaleFactor(nanoEvent, "custom"); // TODO: do we want to use custom for all years?
   // else pileupSF = nanoEventProcessor->GetPileupScaleFactor(nanoEvent, "pileup");
   pileupSF = nanoEventProcessor->GetPileupScaleFactor(nanoEvent, "custom");
-  map<string,float> muonTriggerSF = nanoEventProcessor->GetMuonTriggerScaleFactor(nanoEvent, "muonTriggerIsoMu24");
+  map<string,float> muonTriggerSF = nanoEventProcessor->GetMuonTriggerScaleFactors(nanoEvent, "muonTriggerIsoMu24");
 
   int maxNjets = 4;
   auto leadingJets = eventProcessor->GetLeadingObjects(event, "GoodJets", maxNjets);

--- a/libs/user_extensions/src/TTAlpsEvent.cpp
+++ b/libs/user_extensions/src/TTAlpsEvent.cpp
@@ -31,7 +31,7 @@ TTAlpsEvent::TTAlpsEvent(std::shared_ptr<Event> event_) : event(event_) {
 
 map<string,float> TTAlpsEvent::GetEventWeights() {
   auto nanoEvent = asNanoEvent(event);
-  if (nanoEventProcessor->IsDataEvent(nanoEvent)) return {{"systematic", 1.0}};
+  if (nanoEventProcessor->IsDataEvent(nanoEvent)) return {{"default", 1.0}};
 
   float genWeight = nanoEventProcessor->GetGenWeight(nanoEvent);
 
@@ -58,7 +58,7 @@ map<string,float> TTAlpsEvent::GetEventWeights() {
   map<string,float> muonSF = nanoEventProcessor->GetMuonScaleFactors(muons);
   
   map<string,float> scaleFactorMap;
-  scaleFactorMap["systematic"] = genWeight * pileupSF * muonTriggerSF["systematic"] * btagSF["systematic"] * PUjetIDSF["systematic"] * muonSF["systematic"];
+  scaleFactorMap["default"] = genWeight * pileupSF * muonTriggerSF["systematic"] * btagSF["systematic"] * PUjetIDSF["systematic"] * muonSF["systematic"];
   for (auto &[name, weight]: muonTriggerSF) {
     if (name == "systematic") continue;
     scaleFactorMap[name] = genWeight * pileupSF * muonTriggerSF[name] * btagSF["systematic"] * PUjetIDSF["systematic"] * muonSF["systematic"];

--- a/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
+++ b/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
@@ -184,9 +184,7 @@ void TTAlpsHistogramFiller::FillMuonVertexHistograms(const shared_ptr<NanoDimuon
   histogramsHandler->Fill(name + "_chargeProduct", dimuon->GetDimuonChargeProduct());
 
   histogramsHandler->Fill(name + "_3Dangle", dimuon->Get3DOpeningAngle());
-  histogramsHandler->Fill(name + "_3Dangle2", dimuon->Get3DOpeningAngle2());
   histogramsHandler->Fill(name + "_cos3Dangle", dimuon->GetCosine3DOpeningAngle());
-  histogramsHandler->Fill(name + "_cos3Dangle2", dimuon->GetCosine3DOpeningAngle2());
   histogramsHandler->Fill(name + "_nSegments", dimuon->GetTotalNumberOfSegments());
 
   // Isolations:

--- a/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
+++ b/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
@@ -131,7 +131,7 @@ void TTAlpsHistogramFiller::FillCustomTTAlpsVariablesForMuonVertexCollections(co
   FillNminus1HistogramsForMuonVertexCollection(event);
 }
 
-void TTAlpsHistogramFiller::FillLooseMuonsHistograms(const std::shared_ptr<NanoMuon> muon, std::string names) {
+void TTAlpsHistogramFiller::FillLooseMuonsHistograms(const std::shared_ptr<NanoMuon> muon, std::string name) {
   histogramsHandler->Fill(name + "_pt", muon->Get("pt"));
   histogramsHandler->Fill(name + "_eta", muon->Get("eta"));
   histogramsHandler->Fill(name + "_phi", muon->Get("phi"));
@@ -147,22 +147,6 @@ void TTAlpsHistogramFiller::FillLooseMuonsHistograms(const std::shared_ptr<NanoM
   histogramsHandler->Fill(name + "_IsTight", IsTightMuon);
 }
 
-void TTAlpsHistogramFiller::FillLooseMuonsHistograms(const std::shared_ptr<NanoMuon> muon, std::string name, float weight) {
-  histogramsHandler->Fill(name + "_pt", muon->Get("pt"), weight);
-  histogramsHandler->Fill(name + "_eta", muon->Get("eta"), weight);
-  histogramsHandler->Fill(name + "_phi", muon->Get("phi"), weight);
-  histogramsHandler->Fill(name + "_dxy", muon->Get("dxy"), weight);
-
-  int isPATMuon(0), IsTightMuon(0);
-  if (!muon->IsDSA()) {
-    histogramsHandler->Fill(name + "_pfRelIso04all", muon->Get("pfRelIso04_all"), weight);
-    isPATMuon = 1;
-    if (muon->IsTight()) IsTightMuon = 1;
-  }
-  histogramsHandler->Fill(name + "_isPAT", isPATMuon, weight);
-  histogramsHandler->Fill(name + "_IsTight", IsTightMuon, weight);
-}
-
 void TTAlpsHistogramFiller::FillLooseMuonsHistograms(const shared_ptr<NanoMuons> muons, string collectionName) {
   float size = muons->size();
   histogramsHandler->Fill("Event_n" + collectionName, muons->size());
@@ -176,40 +160,40 @@ void TTAlpsHistogramFiller::FillLooseMuonsHistograms(const shared_ptr<Event> eve
   FillLooseMuonsHistograms(muons, collectionName);
 }
 
-void TTAlpsHistogramFiller::FillMuonVertexHistograms(const shared_ptr<NanoDimuonVertex> dimuon, string name, float weight) {
-  histogramsHandler->Fill(name + "_normChi2", dimuon->Get("normChi2"), weight);
-  histogramsHandler->Fill(name + "_Lxy", dimuon->GetLxyFromPV(), weight);
-  histogramsHandler->Fill(name + "_logLxy", log10(dimuon->GetLxyFromPV()), weight);
-  histogramsHandler->Fill(name + "_LxySigma", dimuon->GetLxySigmaFromPV(), weight);
-  histogramsHandler->Fill(name + "_LxySignificance", dimuon->GetLxyFromPV() / dimuon->GetLxySigmaFromPV(), weight);
-  histogramsHandler->Fill(name + "_dR", dimuon->Get("dR"), weight);
-  histogramsHandler->Fill(name + "_proxDR", dimuon->Get("dRprox"), weight);
-  histogramsHandler->Fill(name + "_outerDR", dimuon->GetOuterDeltaR(), weight);
+void TTAlpsHistogramFiller::FillMuonVertexHistograms(const shared_ptr<NanoDimuonVertex> dimuon, string name) {
+  histogramsHandler->Fill(name + "_normChi2", dimuon->Get("normChi2"));
+  histogramsHandler->Fill(name + "_Lxy", dimuon->GetLxyFromPV());
+  histogramsHandler->Fill(name + "_logLxy", log10(dimuon->GetLxyFromPV()));
+  histogramsHandler->Fill(name + "_LxySigma", dimuon->GetLxySigmaFromPV());
+  histogramsHandler->Fill(name + "_LxySignificance", dimuon->GetLxyFromPV() / dimuon->GetLxySigmaFromPV());
+  histogramsHandler->Fill(name + "_dR", dimuon->Get("dR"));
+  histogramsHandler->Fill(name + "_proxDR", dimuon->Get("dRprox"));
+  histogramsHandler->Fill(name + "_outerDR", dimuon->GetOuterDeltaR());
   histogramsHandler->Fill(name + "_maxHitsInFrontOfVert",
-                          max(float(dimuon->Get("hitsInFrontOfVert1")), float(dimuon->Get("hitsInFrontOfVert2"))), weight);
-  histogramsHandler->Fill(name + "_hitsInFrontOfVert1", dimuon->Get("hitsInFrontOfVert1"), weight);
-  histogramsHandler->Fill(name + "_hitsInFrontOfVert2", dimuon->Get("hitsInFrontOfVert2"), weight);
-  histogramsHandler->Fill(name + "_dca", dimuon->Get("dca"), weight);
-  histogramsHandler->Fill(name + "_absCollinearityAngle", abs(dimuon->GetCollinearityAngle()), weight);
-  histogramsHandler->Fill(name + "_absPtLxyDPhi1", abs(dimuon->GetDPhiBetweenMuonpTAndLxy(1)), weight);
-  histogramsHandler->Fill(name + "_absPtLxyDPhi2", abs(dimuon->GetDPhiBetweenMuonpTAndLxy(2)), weight);
-  histogramsHandler->Fill(name + "_invMass", dimuon->GetInvariantMass(), weight);
-  histogramsHandler->Fill(name + "_logInvMass", log10(dimuon->GetInvariantMass()), weight);
-  histogramsHandler->Fill(name + "_pt", dimuon->GetDimuonPt(), weight);
-  histogramsHandler->Fill(name + "_eta", dimuon->GetDimuonEta(), weight);
-  histogramsHandler->Fill(name + "_dEta", abs(dimuon->GetDeltaEta()), weight);
-  histogramsHandler->Fill(name + "_dPhi", abs(dimuon->GetDeltaPhi()), weight);
-  histogramsHandler->Fill(name + "_chargeProduct", dimuon->GetDimuonChargeProduct(), weight);
+                          max(float(dimuon->Get("hitsInFrontOfVert1")), float(dimuon->Get("hitsInFrontOfVert2"))));
+  histogramsHandler->Fill(name + "_hitsInFrontOfVert1", dimuon->Get("hitsInFrontOfVert1"));
+  histogramsHandler->Fill(name + "_hitsInFrontOfVert2", dimuon->Get("hitsInFrontOfVert2"));
+  histogramsHandler->Fill(name + "_dca", dimuon->Get("dca"));
+  histogramsHandler->Fill(name + "_absCollinearityAngle", abs(dimuon->GetCollinearityAngle()));
+  histogramsHandler->Fill(name + "_absPtLxyDPhi1", abs(dimuon->GetDPhiBetweenMuonpTAndLxy(1)));
+  histogramsHandler->Fill(name + "_absPtLxyDPhi2", abs(dimuon->GetDPhiBetweenMuonpTAndLxy(2)));
+  histogramsHandler->Fill(name + "_invMass", dimuon->GetInvariantMass());
+  histogramsHandler->Fill(name + "_logInvMass", log10(dimuon->GetInvariantMass()));
+  histogramsHandler->Fill(name + "_pt", dimuon->GetDimuonPt());
+  histogramsHandler->Fill(name + "_eta", dimuon->GetDimuonEta());
+  histogramsHandler->Fill(name + "_dEta", abs(dimuon->GetDeltaEta()));
+  histogramsHandler->Fill(name + "_dPhi", abs(dimuon->GetDeltaPhi()));
+  histogramsHandler->Fill(name + "_chargeProduct", dimuon->GetDimuonChargeProduct());
 
-  histogramsHandler->Fill(name + "_3Dangle", dimuon->Get3DOpeningAngle(), weight);
-  histogramsHandler->Fill(name + "_cos3Dangle", dimuon->GetCosine3DOpeningAngle(), weight);
-  histogramsHandler->Fill(name + "_nSegments", dimuon->GetTotalNumberOfSegments(), weight);
+  histogramsHandler->Fill(name + "_3Dangle", dimuon->Get3DOpeningAngle());
+  histogramsHandler->Fill(name + "_cos3Dangle", dimuon->GetCosine3DOpeningAngle());
+  histogramsHandler->Fill(name + "_nSegments", dimuon->GetTotalNumberOfSegments());
 
   // Isolations:
-  histogramsHandler->Fill(name + "_displacedTrackIso03Dimuon1", dimuon->Get("displacedTrackIso03Dimuon1"), weight);
-  histogramsHandler->Fill(name + "_displacedTrackIso04Dimuon1", dimuon->Get("displacedTrackIso04Dimuon1"), weight);
-  histogramsHandler->Fill(name + "_displacedTrackIso03Dimuon2", dimuon->Get("displacedTrackIso03Dimuon2"), weight);
-  histogramsHandler->Fill(name + "_displacedTrackIso04Dimuon2", dimuon->Get("displacedTrackIso04Dimuon2"), weight);
+  histogramsHandler->Fill(name + "_displacedTrackIso03Dimuon1", dimuon->Get("displacedTrackIso03Dimuon1"));
+  histogramsHandler->Fill(name + "_displacedTrackIso04Dimuon1", dimuon->Get("displacedTrackIso04Dimuon1"));
+  histogramsHandler->Fill(name + "_displacedTrackIso03Dimuon2", dimuon->Get("displacedTrackIso03Dimuon2"));
+  histogramsHandler->Fill(name + "_displacedTrackIso04Dimuon2", dimuon->Get("displacedTrackIso04Dimuon2"));
   float pfRelIso04_all1(0), pfRelIso04_all2(0), nSegments1(0), nSegments2(0);
 
   if (name.find("_PatDSA") != string::npos) {
@@ -223,22 +207,17 @@ void TTAlpsHistogramFiller::FillMuonVertexHistograms(const shared_ptr<NanoDimuon
     pfRelIso04_all2 = dimuon->Muon2()->Get("pfRelIso04_all");
   }
 
-  histogramsHandler->Fill(name + "_nSegments1", nSegments1, weight);
-  histogramsHandler->Fill(name + "_nSegments2", nSegments2, weight);
-  histogramsHandler->Fill(name + "_pfRelIso04all1", pfRelIso04_all1, weight);
-  histogramsHandler->Fill(name + "_pfRelIso04all2", pfRelIso04_all2, weight);
+  histogramsHandler->Fill(name + "_nSegments1", nSegments1);
+  histogramsHandler->Fill(name + "_nSegments2", nSegments2);
+  histogramsHandler->Fill(name + "_pfRelIso04all1", pfRelIso04_all1);
+  histogramsHandler->Fill(name + "_pfRelIso04all2", pfRelIso04_all2);
 
   // Muons in vertex variables:
-  histogramsHandler->Fill(name + "_leadingPt", dimuon->GetLeadingMuonPt(), weight);
-  histogramsHandler->Fill(name + "_dxyPVTraj1", dimuon->Muon1()->Get("dxyPVTraj"), weight);
-  histogramsHandler->Fill(name + "_dxyPVTraj2", dimuon->Muon2()->Get("dxyPVTraj"), weight);
-  histogramsHandler->Fill(name + "_dxyPVTrajSig1", (float)dimuon->Muon1()->Get("dxyPVTraj") / (float)dimuon->Muon1()->Get("dxyPVTrajErr"),
-                          weight);
-  histogramsHandler->Fill(name + "_dxyPVTrajSig2", (float)dimuon->Muon2()->Get("dxyPVTraj") / (float)dimuon->Muon2()->Get("dxyPVTrajErr"),
-                          weight);
-
-  histogramsHandler->Fill(name + "_log3Dangle_logLxySignificance", log10(dimuon->Get3DOpeningAngle()),
-                          log10(dimuon->GetLxyFromPV() / dimuon->GetLxySigmaFromPV()), weight);
+  histogramsHandler->Fill(name + "_leadingPt", dimuon->GetLeadingMuonPt());
+  histogramsHandler->Fill(name + "_dxyPVTraj1", dimuon->Muon1()->Get("dxyPVTraj"));
+  histogramsHandler->Fill(name + "_dxyPVTraj2", dimuon->Muon2()->Get("dxyPVTraj"));
+  histogramsHandler->Fill(name + "_dxyPVTrajSig1", (float)dimuon->Muon1()->Get("dxyPVTraj") / (float)dimuon->Muon1()->Get("dxyPVTrajErr"));
+  histogramsHandler->Fill(name + "_dxyPVTrajSig2", (float)dimuon->Muon2()->Get("dxyPVTraj") / (float)dimuon->Muon2()->Get("dxyPVTrajErr"));
 }
 
 void TTAlpsHistogramFiller::FillMuonVertexHistograms(const shared_ptr<Event> event, const shared_ptr<PhysicsObjects> vertexCollection,
@@ -1025,7 +1004,6 @@ void TTAlpsHistogramFiller::FillABCDHistograms(const shared_ptr<Event> event) {
     float angle3D = variables["log3Dangle"];
 
     if (lxySignificance > -2.0 && lxySignificance < -1.0 && angle3D > -1.5 && angle3D < -1.0) {
-      histogramsHandler->Fill(collectionName + "_motherPid1_vs_motherPid2_lowBlob", mother1_pid, mother2_pid);
       histogramsHandler->Fill(collectionName + "_motherPid1_vs_motherPid2_lowBlob", mother1_pid, mother2_pid);
     }
     if (lxySignificance > -0.5 && lxySignificance < 0.5 && angle3D > 0.0 && angle3D < 0.4) {

--- a/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
+++ b/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
@@ -93,16 +93,14 @@ void TTAlpsHistogramFiller::FillDefaultVariables(const shared_ptr<Event> event) 
 
 /// --------- NormCheck Histogram --------- ///
 
-void TTAlpsHistogramFiller::FillNormCheck(const shared_ptr<Event> event) {
+void TTAlpsHistogramFiller::FillNormCheck() {
   histogramsHandler->Fill("Event_normCheck", 0.5);
 }
 
 /// --------- NormCheck Histogram --------- ///
 
 void TTAlpsHistogramFiller::FillDataCheck(const shared_ptr<Event> event) {
-  int isData = 0;
-  if (nanoEventProcessor->IsDataEvent(asNanoEvent(event))) isData = 1;
-  histogramsHandler->Fill("Event_isData", isData);
+  histogramsHandler->Fill("Event_isData", nanoEventProcessor->IsDataEvent(asNanoEvent(event)));
 }
 
 /// --------- LooseMuons Histograms --------- ///
@@ -186,7 +184,9 @@ void TTAlpsHistogramFiller::FillMuonVertexHistograms(const shared_ptr<NanoDimuon
   histogramsHandler->Fill(name + "_chargeProduct", dimuon->GetDimuonChargeProduct());
 
   histogramsHandler->Fill(name + "_3Dangle", dimuon->Get3DOpeningAngle());
+  histogramsHandler->Fill(name + "_3Dangle2", dimuon->Get3DOpeningAngle2());
   histogramsHandler->Fill(name + "_cos3Dangle", dimuon->GetCosine3DOpeningAngle());
+  histogramsHandler->Fill(name + "_cos3Dangle2", dimuon->GetCosine3DOpeningAngle2());
   histogramsHandler->Fill(name + "_nSegments", dimuon->GetTotalNumberOfSegments());
 
   // Isolations:
@@ -213,7 +213,12 @@ void TTAlpsHistogramFiller::FillMuonVertexHistograms(const shared_ptr<NanoDimuon
   histogramsHandler->Fill(name + "_pfRelIso04all2", pfRelIso04_all2);
 
   // Muons in vertex variables:
-  histogramsHandler->Fill(name + "_leadingPt", dimuon->GetLeadingMuonPt());
+  auto leadingMuon = dimuon->GetLeadingMuon();
+  auto subleadingMuon = dimuon->GetSubleadingMuon();
+  histogramsHandler->Fill(name + "_leadingPt", leadingMuon->GetPt());
+  histogramsHandler->Fill(name + "_subleadingPt", subleadingMuon->GetPt());
+  histogramsHandler->Fill(name + "_leadingEta", leadingMuon->GetEta());
+  histogramsHandler->Fill(name + "_subleadingEta", subleadingMuon->GetEta());
   histogramsHandler->Fill(name + "_dxyPVTraj1", dimuon->Muon1()->Get("dxyPVTraj"));
   histogramsHandler->Fill(name + "_dxyPVTraj2", dimuon->Muon2()->Get("dxyPVTraj"));
   histogramsHandler->Fill(name + "_dxyPVTrajSig1", (float)dimuon->Muon1()->Get("dxyPVTraj") / (float)dimuon->Muon1()->Get("dxyPVTrajErr"));

--- a/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
+++ b/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
@@ -924,8 +924,8 @@ void TTAlpsHistogramFiller::FillDimuonCutFlows(const shared_ptr<CutFlowManager> 
     rawEventsCutFlowHist->GetXaxis()->SetBinLabel(bin, get<0>(sortedRawEventsAfterCuts[index]).c_str());
     bin++;
   }
-  histogramsHandler->SetHistogram1D(make_tuple(cutFlowName.c_str(),""), cutFlowHist);
-  histogramsHandler->SetHistogram1D(make_tuple(rawEventsCutFlowName.c_str(),""), rawEventsCutFlowHist);
+  histogramsHandler->SetHistogram1D(make_pair(cutFlowName.c_str(),""), cutFlowHist);
+  histogramsHandler->SetHistogram1D(make_pair(rawEventsCutFlowName.c_str(),""), rawEventsCutFlowHist);
 }
 
 /// --------- ABCD Histograms --------- ///

--- a/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
+++ b/libs/user_extensions/src/TTAlpsHistogramFiller.cpp
@@ -101,7 +101,7 @@ void TTAlpsHistogramFiller::FillNormCheck(const shared_ptr<Event> event) {
 
 void TTAlpsHistogramFiller::FillDataCheck(const shared_ptr<Event> event) {
   int isData = 0;
-  if (asTTAlpsEvent(event)->IsDataEvent()) isData = 1;
+  if (nanoEventProcessor->IsDataEvent(asNanoEvent(event))) isData = 1;
   histogramsHandler->Fill("Event_isData", isData);
 }
 
@@ -924,8 +924,8 @@ void TTAlpsHistogramFiller::FillDimuonCutFlows(const shared_ptr<CutFlowManager> 
     rawEventsCutFlowHist->GetXaxis()->SetBinLabel(bin, get<0>(sortedRawEventsAfterCuts[index]).c_str());
     bin++;
   }
-  histogramsHandler->SetHistogram1D(cutFlowName.c_str(), cutFlowHist);
-  histogramsHandler->SetHistogram1D(rawEventsCutFlowName.c_str(), rawEventsCutFlowHist);
+  histogramsHandler->SetHistogram1D(make_tuple(cutFlowName.c_str(),""), cutFlowHist);
+  histogramsHandler->SetHistogram1D(make_tuple(rawEventsCutFlowName.c_str(),""), rawEventsCutFlowHist);
 }
 
 /// --------- ABCD Histograms --------- ///

--- a/utils/TTAlpsHistogrammerConfigHelper.py
+++ b/utils/TTAlpsHistogrammerConfigHelper.py
@@ -212,9 +212,8 @@ class TTAlpsHistogrammerConfigHelper:
           if variable_1 == variable_2:
             continue
 
-          for category in ["", "_Pat", "_DSA", "_PatDSA"]:
-            params.append((f"{collection}_{variable_2}_vs_{variable_1}{category}",
-                          nBins_1, xMin_1, xMax_1, nBins_2, xMin_2, xMax_2, ""))
+          name = self.__insert_into_name(collection, f"_{variable_2}_vs_{variable_1}")
+          params.append((name, nBins_1, xMin_1, xMax_1, nBins_2, xMin_2, xMax_2, ""))
 
     return tuple(params)
 
@@ -293,6 +292,23 @@ class TTAlpsHistogrammerConfigHelper:
     )
 
     return tuple(params)
+
+  def get_SF_variation_variables(self):
+
+    ABCD_variables = ["logLxySignificance", "log3Dangle"]
+
+    SF_variables = []
+
+    for collection in self.bestMuonVertexCollections: 
+      for variable_1 in ABCD_variables:
+        for variable_2 in ABCD_variables:
+          if variable_2 == variable_1:
+            continue
+          
+          name = self.__insert_into_name(collection, f"_{variable_2}_vs_{variable_1}")
+          SF_variables.append(name)
+
+    return SF_variables
 
   def __insert_into_name(self, collection, to_insert):
     if "_" in collection:

--- a/utils/TTAlpsHistogrammerConfigHelper.py
+++ b/utils/TTAlpsHistogrammerConfigHelper.py
@@ -17,10 +17,13 @@ class TTAlpsHistogrammerConfigHelper:
     self.goodMuonVertexCollections = []
     self.fakeStudyBestMuonVertexCollections = []
 
+    self.bestMuonVertexCollectionCuts = []
+
     if muonVertexCollection is not None:
       for category in ("", "_PatDSA", "_DSA", "_Pat"):
-        self.bestMuonVertexCollections.append(f"{muonVertexCollection}{category}")
-        self.goodMuonVertexCollections.append(f"{muonVertexCollection.replace('Best', 'Good')}{category}")
+        self.bestMuonVertexCollections.append(f"{muonVertexCollection[0]}{category}")
+        self.goodMuonVertexCollections.append(f"{muonVertexCollection[0].replace('Best', 'Good')}{category}")
+      self.bestMuonVertexCollectionCuts = muonVertexCollection[1]
 
     self.looseMuonVertexCollections = []
     for category, matching in product(("", "_PatDSA", "_DSA", "_Pat"), muonMatchingParams):
@@ -82,9 +85,10 @@ class TTAlpsHistogrammerConfigHelper:
     for collection in self.looseMuonVertexCollections + self.bestMuonVertexCollections:
       self.__insert_MuonVertexHistograms(params, collection)
 
-    for collection in self.bestMuonVertexCollections:  
-      name = self.__insert_into_name(collection, "Nminus1")
-      self.__insert_Nminus1Histograms(params, name)
+    for collection in self.bestMuonVertexCollections + self.goodMuonVertexCollections:  
+      for cut in self.bestMuonVertexCollectionCuts:
+        name = self.__insert_into_name(collection, "Nminus1")
+        self.__insert_Nminus1Histograms(params, name)
 
     return tuple(params)
 
@@ -93,8 +97,9 @@ class TTAlpsHistogrammerConfigHelper:
 
     for collection in self.bestMuonVertexCollections + self.goodMuonVertexCollections:
 
-      name = self.__insert_into_name(collection, "FromALPNminus1")
-      self.__insert_Nminus1Histograms(params, name)
+      for cut in self.bestMuonVertexCollectionCuts:
+        name = self.__insert_into_name(collection, "FromALPNminus1")
+        self.__insert_Nminus1Histograms(params, name)
 
     for collection in self.looseMuonVertexCollections + self.bestMuonVertexCollections:
 
@@ -177,7 +182,7 @@ class TTAlpsHistogrammerConfigHelper:
   def get_trigger_params(self):
     params = []
 
-    for name in ["NoExtra", "SingleMuon", "DoubleMuon"]:
+    for name in ["NoExtra", "SingleMuon", "DoubleMuon", "SingleorDoubleMuon"]:
       params += (
           ("Event", "n"+name+"TriggerGenMuonFromALP", 50, 0, 50, ""),
           (name+"TriggerGenMuonFromALP", "pt1", 2000, 0, 1000, ""),
@@ -355,6 +360,9 @@ class TTAlpsHistogrammerConfigHelper:
       (name, "eta", 500, -10, 10, ""),
       (name, "chargeProduct", 4, -2, 2, ""),
       (name, "leadingPt", 2000, 0, 1000, ""),
+      (name, "subleadingPt", 2000, 0, 1000, ""),
+      (name, "leadingEta", 500, -10, 10, ""),
+      (name, "subleadingEta", 500, -10, 10, ""),
       (name, "dxyPVTraj1", 1000, 0, 1000, ""),
       (name, "dxyPVTraj2", 1000, 0, 1000, ""),
       (name, "dxyPVTrajSig1", 1000, 0, 1000, ""),

--- a/utils/TTAlpsHistogrammerConfigHelper.py
+++ b/utils/TTAlpsHistogrammerConfigHelper.py
@@ -68,6 +68,7 @@ class TTAlpsHistogrammerConfigHelper:
     return (
         #  collection         variable                      bins   xmin   xmax    dir
         ("Event", "normCheck", 1, 0, 1, ""),
+        ("Event", "isData",    2, 0, 2, ""),
     )
 
   def get_llp_params(self):

--- a/utils/TTAlpsHistogrammerConfigHelper.py
+++ b/utils/TTAlpsHistogrammerConfigHelper.py
@@ -6,28 +6,25 @@ class TTAlpsHistogrammerConfigHelper:
   def __init__(self, muonMatchingParams, muonVertexCollection):
     self.muonMatchingParams = muonMatchingParams
 
-    self.muonCollections = []
+    self.looseMuonCollections = []
+    self.tightMuonCollections = []
 
     for category, matching in product(("", "DSA", "PAT"), muonMatchingParams):
-      self.muonCollections.append(f"Tight{category}Muons{matching}Match")
-      self.muonCollections.append(f"Loose{category}Muons{matching}Match")
-      self.muonCollections.append(f"Loose{category}Muons{matching}Match_fakes")
-      self.muonCollections.append(f"Loose{category}Muons{matching}Match_nonFakes")
+      self.tightMuonCollections.append(f"Tight{category}Muons{matching}Match")
+      self.looseMuonCollections.append(f"Loose{category}Muons{matching}Match")
 
-    self.muonVertexCollections = []
-
-    for category in ("", "_PatDSA", "_DSA", "_Pat"):
-      self.muonVertexCollections.append(f"{muonVertexCollection}{category}")
-      self.muonVertexCollections.append(f"{muonVertexCollection}{category}_fakes")
-      self.muonVertexCollections.append(f"{muonVertexCollection}{category}_nonFakes")
-
-    for category, matching in product(("", "_PatDSA", "_DSA", "_Pat"), muonMatchingParams):
-      self.muonVertexCollections.append(f"LooseMuonsVertex{matching}Match{category}")
+    self.bestMuonVertexCollections = []
+    self.goodMuonVertexCollections = []
+    self.fakeStudyBestMuonVertexCollections = []
 
     if muonVertexCollection is not None:
       for category in ("", "_PatDSA", "_DSA", "_Pat"):
-        self.muonVertexCollections.append(f"{muonVertexCollection}{category}")
-        self.muonVertexCollections.append(f"{muonVertexCollection.replace('Best', 'Good')}{category}")
+        self.bestMuonVertexCollections.append(f"{muonVertexCollection}{category}")
+        self.goodMuonVertexCollections.append(f"{muonVertexCollection.replace('Best', 'Good')}{category}")
+
+    self.looseMuonVertexCollections = []
+    for category, matching in product(("", "_PatDSA", "_DSA", "_Pat"), muonMatchingParams):
+      self.looseMuonVertexCollections.append(f"LooseMuonsVertex{matching}Match{category}")
 
   def get_default_params(self):
     return (
@@ -79,45 +76,51 @@ class TTAlpsHistogrammerConfigHelper:
   def get_llp_params(self):
     params = []
 
-    for collection in self.muonCollections:
+    for collection in self.looseMuonCollections:
       self.__insert_MuonHistograms(params, collection)
 
-    for collection in self.muonVertexCollections:
+    for collection in self.looseMuonVertexCollections + self.bestMuonVertexCollections:
       self.__insert_MuonVertexHistograms(params, collection)
 
+    for collection in self.bestMuonVertexCollections:  
+      name = self.__insert_into_name(collection, "Nminus1")
+      self.__insert_Nminus1Histograms(params, name)
+
     return tuple(params)
 
-  def get_nminus1_params(self):
+  def get_gen_vertex_params(self):
     params = []
 
-    for collection in self.muonVertexCollections:
-      if not collection.startswith("Best") and not collection.startswith("Good"):
-        continue
+    for collection in self.bestMuonVertexCollections + self.goodMuonVertexCollections:
 
-      names = (
-          self.__insert_into_name(collection, "Nminus1"),
-          self.__insert_into_name(collection, "FromALPNminus1")
-      )
-      for name in names:
-        self.__insert_Nminus1Histograms(params, name)
-    return tuple(params)
+      name = self.__insert_into_name(collection, "FromALPNminus1")
+      self.__insert_Nminus1Histograms(params, name)
 
-  def get_gen_matched_params(self):
-    params = []
-
-    for collection in self.muonVertexCollections:
+    for collection in self.looseMuonVertexCollections + self.bestMuonVertexCollections:
 
       names = (
           self.__insert_into_name(collection, "FromALP"),
           self.__insert_into_name(collection, "ResonancesNotFromALP"),
           self.__insert_into_name(collection, "NonresonancesNotFromALP"),
       )
-
       for name in names:
-        self.__insert_MuonHistograms(params, name)
         self.__insert_MuonVertexHistograms(params, name)
 
-    for collection in self.muonCollections:
+    return tuple(params)
+
+  def get_gen_matched_params(self):
+    params = []
+
+    for collection in self.looseMuonVertexCollections:
+      names = (
+          self.__insert_into_name(collection, "FromALP"),
+          self.__insert_into_name(collection, "ResonancesNotFromALP"),
+          self.__insert_into_name(collection, "NonresonancesNotFromALP"),
+      )
+      for name in names:
+        self.__insert_MuonVertexHistograms(params, name)
+
+    for collection in self.looseMuonCollections + self.tightMuonCollections:
       names = (
           self.__insert_into_name(collection, "FromALP"),
           self.__insert_into_name(collection, "FromW"),
@@ -150,67 +153,23 @@ class TTAlpsHistogrammerConfigHelper:
     )
 
     for name in ["GenDimuonFromALP", "GenDimuonResonancesNotFromALP", "GenDimuonsNonresonancesNotFromALP", "GenMuonFromW"]:
-      for i in range(1, 6):
+      self.__insert_GenDimuonHistograms(params, name)
+
+    for matchingMethod in self.muonMatchingParams:
+      for name in ["GenDimuonFromALP", "GenMuonFromW"]:
         params += (
-            (name, "motherID1"+str(i), 10010, -10, 10000, ""),
-            (name, "motherID2"+str(i), 10010, -10, 10000, ""),
-        )
-      params += (
-          ("Event", "n"+name, 50, 0, 50, ""),
-          (name, "index1", 100, 0, 100, ""),
-          (name, "index2", 100, 0, 100, ""),
-          (name, "index3", 100, 0, 100, ""),
-          (name, "Lxy", 50000, 0, 5000, ""),
-          (name, "Lxyz", 50000, 0, 5000, ""),
-          (name, "properLxy", 50000, 0, 5000, ""),
-          (name, "invMass", 20000, 0, 200, ""),
-          (name, "logInvMass", 1000, -1, 2, ""),
-          (name, "deltaR", 1000, 0, 10, ""),
-          (name, "absCollinearityAngle", 500, 0, 5, ""),
-          (name, "absPtLxyDPhi1", 500, 0, 5, ""),
-          (name, "absPtLxyDPhi2", 500, 0, 5, ""),
-          (name, "logLxy", 2000, -10, 10, ""),
-      )
-
-      for matchingMethod in self.muonMatchingParams:
-        for name in ["GenDimuonFromALP", "GenMuonFromW"]:
-          params += (
-              (name+"1", "LooseMuons"+matchingMethod+"MatchMinDR", 1000, 0, 10, ""),
-              (name+"1", "LooseMuons"+matchingMethod+"MatchMinDPhi", 1000, 0, 10, ""),
-              (name+"1", "LooseMuons"+matchingMethod+"MatchMinDEta", 1000, 0, 10, ""),
-              (name+"2", "LooseMuons"+matchingMethod+"MatchMinDR", 1000, 0, 10, ""),
-              (name+"2", "LooseMuons"+matchingMethod+"MatchMinDPhi", 1000, 0, 10, ""),
-              (name+"2", "LooseMuons"+matchingMethod+"MatchMinDEta", 1000, 0, 10, ""),
-              (name+"1", "LooseMuons"+matchingMethod+"MatchFinalMinDR", 1000, 0, 10, ""),
-              (name+"1", "LooseMuons"+matchingMethod+"MatchFinalMinDPhi", 1000, 0, 10, ""),
-              (name+"1", "LooseMuons"+matchingMethod+"MatchFinalMinDEta", 1000, 0, 10, ""),
-              (name+"2", "LooseMuons"+matchingMethod+"MatchFinalMinDR", 1000, 0, 10, ""),
-              (name+"2", "LooseMuons"+matchingMethod+"MatchFinalMinDPhi", 1000, 0, 10, ""),
-              (name+"2", "LooseMuons"+matchingMethod+"MatchFinalMinDEta", 1000, 0, 10, ""),
-          )
-
-    return tuple(params)
-
-  def get_2D_params(self):
-    params = []
-
-    for collection in self.muonVertexCollections:
-
-      params += (
-          (collection+"_log3Dangle_logLxySignificance", 100, -3, 1, 100, -2, 2, ""),
-      )
-
-      names = (
-          self.__insert_into_name(collection, "FromALP"),
-          self.__insert_into_name(collection, "NotFromALP"),
-          self.__insert_into_name(collection, "NonResonant"),
-          self.__insert_into_name(collection, "ResonancesNotFromALP"),
-          self.__insert_into_name(collection, "NonresonancesNotFromALP"),
-      )
-
-      for name in names:
-        params += (
-            (name+"_log3Dangle_logLxySignificance", 100, -3, 1, 100, -2, 2, ""),
+            (name+"1", "LooseMuons"+matchingMethod+"MatchMinDR", 1000, 0, 10, ""),
+            (name+"1", "LooseMuons"+matchingMethod+"MatchMinDPhi", 1000, 0, 10, ""),
+            (name+"1", "LooseMuons"+matchingMethod+"MatchMinDEta", 1000, 0, 10, ""),
+            (name+"2", "LooseMuons"+matchingMethod+"MatchMinDR", 1000, 0, 10, ""),
+            (name+"2", "LooseMuons"+matchingMethod+"MatchMinDPhi", 1000, 0, 10, ""),
+            (name+"2", "LooseMuons"+matchingMethod+"MatchMinDEta", 1000, 0, 10, ""),
+            (name+"1", "LooseMuons"+matchingMethod+"MatchFinalMinDR", 1000, 0, 10, ""),
+            (name+"1", "LooseMuons"+matchingMethod+"MatchFinalMinDPhi", 1000, 0, 10, ""),
+            (name+"1", "LooseMuons"+matchingMethod+"MatchFinalMinDEta", 1000, 0, 10, ""),
+            (name+"2", "LooseMuons"+matchingMethod+"MatchFinalMinDR", 1000, 0, 10, ""),
+            (name+"2", "LooseMuons"+matchingMethod+"MatchFinalMinDPhi", 1000, 0, 10, ""),
+            (name+"2", "LooseMuons"+matchingMethod+"MatchFinalMinDEta", 1000, 0, 10, ""),
         )
 
     return tuple(params)
@@ -229,7 +188,7 @@ class TTAlpsHistogrammerConfigHelper:
 
     return tuple(params)
 
-  def get_abcd_params(self):
+  def get_abcd_2Dparams(self):
     ABCD_variables = {
         "Lxy": (100, 0, 1000),
         "LxySignificance": (100, 0, 100),
@@ -244,7 +203,7 @@ class TTAlpsHistogrammerConfigHelper:
 
     params = []
 
-    for collection in self.muonVertexCollections:
+    for collection in self.bestMuonVertexCollections:
       for blob in ["", "_lowBlob", "_rightBlob", "_centralBlob", "_lowLine", "_rightLine"]:
         params.append((collection+"_motherPid1_vs_motherPid2"+blob, 2000, -1000, 1000, 2000, -1000, 1000, ""))
 
@@ -256,6 +215,28 @@ class TTAlpsHistogrammerConfigHelper:
           for category in ["", "_Pat", "_DSA", "_PatDSA"]:
             params.append((f"{collection}_{variable_2}_vs_{variable_1}{category}",
                           nBins_1, xMin_1, xMax_1, nBins_2, xMin_2, xMax_2, ""))
+
+    return tuple(params)
+
+  def get_abcd_1Dparams(self):
+    params = []
+
+    for collection in self.bestMuonVertexCollections:
+      params += (
+        (collection, "deltaR_WW", 500, 0, 10, ""),
+        (collection, "deltaR_Wtau", 500, 0, 10, ""),
+        (collection, "deltaR_OS", 500, 0, 10, ""),
+        (collection, "logDeltaR_WW", 100, -5, 5, ""),
+        (collection, "logDeltaR_Wtau", 100, -5, 5, ""),
+        (collection, "logDeltaR_OS", 100, -5, -5, ""),
+      )
+
+      for type in ["_fakes", "_nonFakes"]:
+        self.__insert_MuonVertexHistograms(params, collection + type)
+
+    for collection in self.looseMuonCollections:
+      for type in ["_fakes", "_nonFakes"]:
+        self.__insert_MuonHistograms(params, collection + type)
 
     return tuple(params)
 
@@ -331,67 +312,86 @@ class TTAlpsHistogrammerConfigHelper:
         (name, "IsTight", 10, 0, 10, ""),
     )
 
+  ## FillMuonVertexHistograms function
   def __insert_MuonVertexHistograms(self, params, name):
     params += (
-        ("Event", "n"+name, 50, 0, 50, ""),
-        (name, "normChi2", 50000, 0, 50, ""),
-        (name, "Lxy", 10000, 0, 1000, ""),
-        (name, "logLxy", 2000, -10, 10, ""),
-        (name, "LxySigma", 10000, 0, 100, ""),
-        (name, "LxySignificance", 1000, 0, 1000, ""),
-        (name, "dR", 500, 0, 10, ""),
-        (name, "deltaR_WW", 500, 0, 10, ""),
-        (name, "deltaR_Wtau", 500, 0, 10, ""),
-        (name, "deltaR_OS", 500, 0, 10, ""),
-        (name, "logDeltaR_WW", 100, -5, 5, ""),
-        (name, "logDeltaR_Wtau", 100, -5, 5, ""),
-        (name, "logDeltaR_OS", 100, -5, -5, ""),
-        (name, "proxDR", 500, 0, 10, ""),
-        (name, "outerDR", 500, 0, 10, ""),
-        (name, "dEta", 500, 0, 10, ""),
-        (name, "dPhi", 500, 0, 10, ""),
-        (name, "maxHitsInFrontOfVert", 100, 0, 100, ""),
-        (name, "hitsInFrontOfVert1", 100, 0, 100, ""),
-        (name, "hitsInFrontOfVert2", 100, 0, 100, ""),
-        (name, "dca", 1000, 0, 20, ""),
-        (name, "absCollinearityAngle", 500, 0, 5, ""),
-        (name, "absPtLxyDPhi1", 500, 0, 5, ""),
-        (name, "absPtLxyDPhi2", 500, 0, 5, ""),
-        (name, "invMass", 20000, 0, 200, ""),
-        (name, "logInvMass", 1000, -1, 2, ""),
-        (name, "pt", 2000, 0, 1000, ""),
-        (name, "eta", 500, -10, 10, ""),
-        (name, "chargeProduct", 4, -2, 2, ""),
-        (name, "leadingPt", 2000, 0, 1000, ""),
-        (name, "dxyPVTraj1", 1000, 0, 1000, ""),
-        (name, "dxyPVTraj2", 1000, 0, 1000, ""),
-        (name, "dxyPVTrajSig1", 1000, 0, 1000, ""),
-        (name, "dxyPVTrajSig2", 1000, 0, 1000, ""),
-        (name, "displacedTrackIso03Dimuon1", 800, 0, 20, ""),
-        (name, "displacedTrackIso04Dimuon1", 800, 0, 20, ""),
-        (name, "displacedTrackIso03Dimuon2", 800, 0, 20, ""),
-        (name, "displacedTrackIso04Dimuon2", 800, 0, 20, ""),
-        (name, "pfRelIso04all1", 800, 0, 20, ""),
-        (name, "pfRelIso04all2", 800, 0, 20, ""),
-        (name, "3Dangle", 2000, -10, 10, ""),
-        (name, "cos3Dangle", 400, -2, 2, ""),
-        (name, "nSegments", 50, 0, 50, ""),
-        (name, "nSegments1", 50, 0, 50, ""),
-        (name, "nSegments2", 50, 0, 50, ""),
+      ("Event", "n"+name, 50, 0, 50, ""),
+      (name, "normChi2", 50000, 0, 50, ""),
+      (name, "Lxy", 10000, 0, 1000, ""),
+      (name, "logLxy", 2000, -10, 10, ""),
+      (name, "LxySigma", 10000, 0, 100, ""),
+      (name, "LxySignificance", 1000, 0, 1000, ""),
+      (name, "dR", 500, 0, 10, ""),
+      (name, "proxDR", 500, 0, 10, ""),
+      (name, "outerDR", 500, 0, 10, ""),
+      (name, "dEta", 500, 0, 10, ""),
+      (name, "dPhi", 500, 0, 10, ""),
+      (name, "maxHitsInFrontOfVert", 100, 0, 100, ""),
+      (name, "hitsInFrontOfVert1", 100, 0, 100, ""),
+      (name, "hitsInFrontOfVert2", 100, 0, 100, ""),
+      (name, "dca", 1000, 0, 20, ""),
+      (name, "absCollinearityAngle", 500, 0, 5, ""),
+      (name, "absPtLxyDPhi1", 500, 0, 5, ""),
+      (name, "absPtLxyDPhi2", 500, 0, 5, ""),
+      (name, "invMass", 20000, 0, 200, ""),
+      (name, "logInvMass", 1000, -1, 2, ""),
+      (name, "pt", 2000, 0, 1000, ""),
+      (name, "eta", 500, -10, 10, ""),
+      (name, "chargeProduct", 4, -2, 2, ""),
+      (name, "leadingPt", 2000, 0, 1000, ""),
+      (name, "dxyPVTraj1", 1000, 0, 1000, ""),
+      (name, "dxyPVTraj2", 1000, 0, 1000, ""),
+      (name, "dxyPVTrajSig1", 1000, 0, 1000, ""),
+      (name, "dxyPVTrajSig2", 1000, 0, 1000, ""),
+      (name, "displacedTrackIso03Dimuon1", 800, 0, 20, ""),
+      (name, "displacedTrackIso04Dimuon1", 800, 0, 20, ""),
+      (name, "displacedTrackIso03Dimuon2", 800, 0, 20, ""),
+      (name, "displacedTrackIso04Dimuon2", 800, 0, 20, ""),
+      (name, "pfRelIso04all1", 800, 0, 20, ""),
+      (name, "pfRelIso04all2", 800, 0, 20, ""),
+      (name, "3Dangle", 2000, -10, 10, ""),
+      (name, "cos3Dangle", 400, -2, 2, ""),
+      (name, "nSegments", 50, 0, 50, ""),
+      (name, "nSegments1", 50, 0, 50, ""),
+      (name, "nSegments2", 50, 0, 50, ""),
     )
 
   def __insert_Nminus1Histograms(self, params, name):
     params += (
-        (name, "invMass", 20000, 0, 200, ""),
-        (name, "logInvMass", 1000, -1, 2, ""),
-        (name, "chargeProduct", 4, -2, 2, ""),
-        (name, "maxHitsInFrontOfVert", 100, 0, 100, ""),
-        (name, "absPtLxyDPhi1", 500, 0, 5, ""),
-        (name, "dca", 1000, 0, 20, ""),
-        (name, "absCollinearityAngle", 500, 0, 5, ""),
-        (name, "normChi2", 50000, 0, 50, ""),
-        (name, "displacedTrackIso03Dimuon1", 800, 0, 20, ""),
-        (name, "displacedTrackIso03Dimuon2", 800, 0, 20, ""),
-        (name, "pfRelIso1", 800, 0, 20, ""),
-        (name, "pfRelIso2", 800, 0, 20, ""),
+      (name, "invMass", 20000, 0, 200, ""),
+      (name, "logInvMass", 1000, -1, 2, ""),
+      (name, "chargeProduct", 4, -2, 2, ""),
+      (name, "maxHitsInFrontOfVert", 100, 0, 100, ""),
+      (name, "absPtLxyDPhi1", 500, 0, 5, ""),
+      (name, "dca", 1000, 0, 20, ""),
+      (name, "absCollinearityAngle", 500, 0, 5, ""),
+      (name, "normChi2", 50000, 0, 50, ""),
+      (name, "displacedTrackIso03Dimuon1", 800, 0, 20, ""),
+      (name, "displacedTrackIso03Dimuon2", 800, 0, 20, ""),
+      (name, "pfRelIso1", 800, 0, 20, ""),
+      (name, "pfRelIso2", 800, 0, 20, ""),
+    )
+
+  ## For FillGenDimuonHistograms function
+  def __insert_GenDimuonHistograms(self, params, name):
+    for i in range(1, 6):
+      params += (
+          (name, "motherID1"+str(i), 10010, -10, 10000, ""),
+          (name, "motherID2"+str(i), 10010, -10, 10000, ""),
+      )
+    params += (
+      ("Event", "n"+name, 50, 0, 50, ""),
+      (name, "index1", 100, 0, 100, ""),
+      (name, "index2", 100, 0, 100, ""),
+      (name, "index3", 100, 0, 100, ""),
+      (name, "Lxy", 50000, 0, 5000, ""),
+      (name, "Lxyz", 50000, 0, 5000, ""),
+      (name, "properLxy", 50000, 0, 5000, ""),
+      (name, "invMass", 20000, 0, 200, ""),
+      (name, "logInvMass", 1000, -1, 2, ""),
+      (name, "deltaR", 1000, 0, 10, ""),
+      (name, "absCollinearityAngle", 500, 0, 5, ""),
+      (name, "absPtLxyDPhi1", 500, 0, 5, ""),
+      (name, "absPtLxyDPhi2", 500, 0, 5, ""),
+      (name, "logLxy", 2000, -10, 10, ""),
     )

--- a/utils/merge_histograms.py
+++ b/utils/merge_histograms.py
@@ -10,27 +10,34 @@ output_username = os.environ["USER"]
 
 # SR (+J/Psi CR), tt̄ CR, and QCD CR, with no isolation requirement on the loose muons
 # skim = ("skimmed_looseSemimuonic_v2_SR", "_SRDimuons")
-# skim = ("skimmed_looseSemimuonic_v2_SR", "_JPsiDimuons")
+skim = ("skimmed_looseSemimuonic_v2_SR", "_JPsiDimuons")
 # skim = ("skimmed_looseSemimuonic_v2_SR", "_ZDimuons")
 # skim = ("skimmed_looseSemimuonic_v2_ttbarCR", "")
 # skim = ("skimmed_looseNonTT_v1_QCDCR", "_SRDimuons")
 # skim = ("skimmed_looseNoBjets_lt4jets_v1_QCDCR", "_SRDimuons")
 # skim = ("skimmed_loose_lt3bjets_lt4jets_v1_WjetsCR", "_SRDimuons")
-skim = ("skimmed_loose_lt3bjets_lt4jets_v1_bbCR", "_SRDimuons")
+# skim = ("skimmed_loose_lt3bjets_lt4jets_v1_bbCR", "_SRDimuons")
 
 # Loose semimuonic skim with Dimuon triggers for LLP trigger study
 # skim = ("skimmed_looseSemimuonicv1_LLPtrigger", "_SRDimuons_TriggerStudy")
 # skim = ("skimmed_looseSemimuonic_SRmuonic_Segmentv1_NonIso_LLPtrigger", "_SRDimuons_TriggerStudy")
 
-hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs{skim[1]}"
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs{skim[1]}"
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}"
+hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # all SFs
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_bTaggingSFs{skim[1]}_newSFs" # no PUjetIDSFs
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_pileupSFs_PUjetIDSFs{skim[1]}_newSFs" # no bTaggingSFs
+# hist_path = f"histograms_muonSFs_muonTriggerSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no pilup
+# hist_path = f"histograms_muonSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no muonTriggerSFs
+# hist_path = f"histograms_muonTriggerSFs_pileupSFs_bTaggingSFs_PUjetIDSFs{skim[1]}_newSFs" # no muonSF
 
 # ------------------------------------------------------------------------------
 # Samples
 # ------------------------------------------------------------------------------
 
-sample_paths = dasSamples2018.keys()
+# sample_paths = dasSamples2018.keys()
 # sample_paths = dasData2018.keys()
-# sample_paths = QCD_dasBackgrounds2018.keys()
+sample_paths = dasBackgrounds2018.keys()
 # sample_paths = TT_dasBackgrounds2018.keys()
 # sample_paths = dasSignals2018_2GeV.keys()
 


### PR DESCRIPTION
I'm getting the SF in TTAlpsEvent and then set them in the HistogramHandler in the ttalps_histogrammer.cpp event loop. eventWeights["central"] is the standard SF values. 

I also save SF variations if extraSFs has string uncommented (comment them out to not use them). But I only save variations for extraSFsHistParams2D which I've just set to extraSFsHistParams2D = helper.get_abcd_2Dparams() in our histogrammer config.

Other small changes:
- restructed the histogram definitions a little so now we should create less histograms if we set flags to False
- included met_filters for different years
- runPileupHistograms flag just created default histograms so I removed it

